### PR TITLE
Run composer install only if .lock exists

### DIFF
--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -97,9 +97,9 @@ services:
   # - nodejs_my_other_theme.
   nodejs:
     image: wodby/drupal-node:1.0-1.0.0
-    working_dir: /var/www/web/themes/custom/MYTHEME
+    working_dir: /var/www
     volumes:
-      - ./app/web/themes/custom/MYTHEME:/var/www/web/themes/custom/MYTHEME:delegated
+      - ./app:/var/www/:delegated
     command: sh -c '[[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -47,7 +47,7 @@ services:
     env_file:
       - .env
     working_dir: /var/www
-    command: /usr/local/bin/composer install
+    command: sh -c '[[ ! -e "/var/www/composer.lock" ]] && exit 0 || /usr/local/bin/composer install'
 
   db:
     # mysql:8.0.11 keeps restarting.

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -106,9 +106,9 @@ services:
   # - nodejs_my_other_theme.
   nodejs:
     image: wodby/drupal-node:1.0-1.0.0
-    working_dir: /var/www/web/themes/custom/MYTHEME
+    working_dir: /var/www
     volumes:
-      - ./app/web/themes/custom/MYTHEME:/var/www/web/themes/custom/MYTHEME:delegated
+      - ./app:/var/www/:delegated
     command: sh -c '[[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -51,7 +51,7 @@ services:
     env_file:
       - .env
     working_dir: /var/www
-    command: /usr/local/bin/composer install
+    command: sh -c '[[ ! -e "/var/www/composer.lock" ]] && exit 0 || /usr/local/bin/composer install'
 
   db:
     # mysql:8.0.11 keeps restarting.

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -100,9 +100,9 @@ services:
   # - nodejs_my_other_theme.
   nodejs:
     image: wodby/drupal-node:1.0-1.0.0
-    working_dir: /var/www/web/themes/custom/MYTHEME
+    working_dir: /var/www
     volumes:
-      - ./app/web/themes/custom/MYTHEME:/var/www/web/themes/custom/MYTHEME:delegated
+      - ./app:/var/www/:delegated
     command: sh -c '[[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -50,7 +50,7 @@ services:
     env_file:
       - .env
     working_dir: /var/www
-    command: /usr/local/bin/composer install
+    command: sh -c '[[ ! -e "/var/www/composer.lock" ]] && exit 0 || /usr/local/bin/composer install'
 
   db:
     # mysql:8.0.11 keeps restarting.

--- a/ld.sh
+++ b/ld.sh
@@ -454,7 +454,7 @@ case "$ACTION" in
 
 "drupal-files-folder-perms")
     echo 'Restoring files directory ownership...'
-    docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_PHP ba2esh -c "chown -R www-data:www-data /var/www/web/sites/*/files"
+    docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_PHP bash -c "chown -R www-data:www-data /var/www/web/sites/*/files"
     echo 'Restoring done.'
     ;;
 

--- a/ld.sh
+++ b/ld.sh
@@ -175,6 +175,20 @@ case "$ACTION" in
             n|N|'no'|'NO' ) echo "Volume names will start with 'webroot-'";;
         esac
     fi
+    if [[ "$(docker-compose -f $DOCKER_COMPOSE_FILE ps)" ]]; then
+        echo "Turning off current container stack."
+        docker-compose -f $DOCKER_COMPOSE_FILE down
+        echo 'ALL containers: stopped.'
+    fi
+    if [ "$IS_DOCKERSYNC" -eq "1" ]; then
+        docker-sync clean
+        docker-sync start
+    fi
+    echo 'Starting PHP container only, to use it to build the codebase.'
+    docker-compose -f $DOCKER_COMPOSE_FILE up -d php
+    echo 'PHP container: started.'
+
+    DELETE_ROOT=
     if [ -e "$APP_ROOT""composer.json" ]; then
       echo "Looks like project is already created? File "$APP_ROOT"composer.json exists."
       echo "Maybe you should install composer codebase instead:"
@@ -183,24 +197,43 @@ case "$ACTION" in
     elif [ ! -d "$APP_ROOT" ]; then
       mkdir $APP_ROOT;
     fi
+    echo "Verify application root can be used to install codebase (must be empty)..."
+    APP_ROOT_FILES="ls -lha /var/www"
+    echo "Next: $APP_ROOT_FILES"
+    docker-compose -f $DOCKER_COMPOSE_FILE exec php bash -c "$APP_ROOT_FILES"
+    echo "Currently on host $APP_ROOT:"
+    ls -lha $APP_ROOT
+
+    if [ "$(ls -A $APP_ROOT)" ]; then
+      echo "Application root folder $APP_ROOT is not empty. Installation requires an empty folder. Currently there is: "
+      ls -A $APP_ROOT
+      read -p "WARNING: If you continue all of these will be deleted. Type 'PLEASE-DELETE' to continue: " CHOICE
+      case "$CHOICE" in
+          'PLEASE-DELETE' ) rm -rf $APP_ROOT && mkdir $APP_ROOT && DELETE_ROOT=1;;
+          * ) echo "Clear the folder manually and start overm - or initialize codebase manually." && exit;;
+      esac
+    fi
+
     echo
     echo 'Installing Drupal project, please wait...'
-    if [ "$IS_DOCKERSYNC" -eq "1" ]; then
-        docker-sync start
+    echo "============="
+    if [[ ! -z "$DELETE_ROOT" ]]; then
+        echo "Clearing old things from the app root."
+        CLEAN_ROOT="rm -rf /var/www/*"
+        echo "Next: $CLEAN_ROOT"
+        docker-compose -f $DOCKER_COMPOSE_FILE exec php bash -c "$CLEAN_ROOT"
     fi
+
     # Use verbose output on this composer command.
     COMPOSER_INIT="composer -vv create-project drupal-composer/drupal-project:8.x-dev /var/www --no-interaction --stability=dev"
-    docker-compose -f $DOCKER_COMPOSE_FILE up -d php
+    echo "Next: $COMPOSER_INIT"
+    docker-compose -f $DOCKER_COMPOSE_FILE exec php bash -c "$COMPOSER_INIT"
     OK=$?
     if [ "$OK" -ne "0" ]; then
         echo "ERROR: Something went wrong when initializing the codebase."
         echo "Check that required ports are not allocated (by other containers or programs) and re-configure them if needed."
         exit 1
     fi
-
-    echo "============="
-    echo "Next: $COMPOSER_INIT"
-    docker-compose -f $DOCKER_COMPOSE_FILE exec php bash -c "$COMPOSER_INIT"
     echo "============="
     echo "Project created to ./$APP_ROOT -folder (/var/www in containers)"
     # This must be run after composer install.


### PR DESCRIPTION
Fixes issue #6 

with this change `comopser` container executes `composer install` only when `composer.lock` file exists. In the essence check prevents `composer` container to run in parallel when `./ld init` creates the codebase (`composer create-project ...`)

