### PR TITLE
Issue 46 make project structure init parameter

### DIFF
--- a/docker/scripts/ld.command.composer.sh
+++ b/docker/scripts/ld.command.composer.sh
@@ -14,7 +14,7 @@ function ld_command_composer_exec() {
         echo -e "${Red}ERROR: PHP container ('$CONTAINER_PHP')is not up.${Color_Off}"
         exit 1
     fi
-    COMM="docker-compose exec ${CONTAINER_PHP} /usr/local/bin/composer -vv ${@:2}"
+    COMM="docker-compose exec ${CONTAINER_PHP} /usr/local/bin/composer -vv $@"
     echo -e "${Cyan}Next: $COMM${Color_Off}"
     $COMM
 }

--- a/docker/scripts/ld.command.drush.sh
+++ b/docker/scripts/ld.command.drush.sh
@@ -14,7 +14,7 @@ function ld_command_drush_exec() {
         echo -e "${Red}ERROR: PHP container ('$CONTAINER_PHP')is not up.${Color_Off}"
         exit 1
     fi
-    COMM="docker-compose exec ${CONTAINER_PHP} /var/www/vendor/drush/drush/drush ${@:2}"
+    COMM="docker-compose exec ${CONTAINER_PHP} /var/www/vendor/drush/drush/drush $@"
     echo -e "${Cyan}Next: $COMM${Color_Off}"
     $COMM
 }

--- a/docker/scripts/ld.command.dump.sh
+++ b/docker/scripts/ld.command.dump.sh
@@ -14,7 +14,7 @@ function ld_command_dump_exec() {
     echo "${Yellow}Using datestamp: $DATE${Color_Off}"
     DUMPER="mysqldump --host "$CONTAINER_DB" -uroot -p"$MYSQL_ROOT_PASSWORD" --all-databases --lock-all-tables --compress --flush-logs --flush-privileges  --dump-date --tz-utc --verbose"
     docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_DB sh -c "$DUMPER  2>/dev/null | gzip --fast -f > /var/db_dumps/db-container-dump-$DATE.sql.gz"
-    cd $PROJECT_ROOT/db_dumps
+    cd $PROJECT_ROOT/$DATABASE_DUMP_STORAGE
     ln -sf db-container-dump-$DATE.sql.gz db-container-dump-LATEST.sql.gz
     cd $PROJECT_ROOT
     echo "DB backup in db_dumps/db-container-dump-$DATE.sql.gz"

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -96,8 +96,8 @@ function ld_command_init_exec() {
     echo 'PHP container: started.'
 
     DELETE_ROOT=
-    if [ -e "$APP_ROOT""composer.json" ]; then
-        echo -e "${Yellow}Looks like project is already created? File "$APP_ROOT"composer.json exists.${Color_Off}"
+    if [ -e "${APP_ROOT}/composer.json" ]; then
+        echo -e "${Yellow}Looks like project is already created? File "$APP_ROOT"/composer.json exists.${Color_Off}"
         echo -e "${Yellow}Maybe you should install codebase using composer:${Color_Off}"
         echo -e "${Yellow}$SCRIPT_NAME_SHORT up && $SCRIPT_NAME_SHORT composer install${Color_Off}"
         cd $CWD
@@ -162,5 +162,5 @@ function ld_command_init_exec() {
 }
 
 function ld_command_init_help() {
-    echo "Builds project to ./app -folder, using composer and drupal-project (default)"
+    echo "Builds the project (default: codebase in./app -folder, use composer, use drupal-project)"
 }

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -4,26 +4,85 @@
 # This file contains init -command for local-docker script ld.sh.
 
 function ld_command_init_exec() {
+
+    VALID=0
+    while [ "$VALID" -eq "0" ]; do
+        echo  -e "${BBlack}What is the project name?${Color_Off}"
+        echo  "Provide a string without spaces and use chars a-z and 0-9."
+        PROJECT_NAME=$(basename $PROJECT_ROOT)
+        read -p "Project name ['$PROJECT_NAME']: " ANSWER
+        if [ -z "$ANSWER" ]; then
+            VALID=1
+        elif [[ "$ANSWER" =~ ^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$ ]]; then
+            PROJECT_NAME=$ANSWER
+            VALID=1
+        else
+            echo -e "${Red}ERROR: Project name can contain only alphabetic characters (a-z), numbers (0-9), underscore (_) and hyphen (-).${Color_Off}"
+            echo -e "${Red}ERROR: Also the project name must not start or end with underscore or hyphen.${Color_Off}"
+            sleep 2
+            echo
+        fi
+    done;
+    # Remove spaces.
+    PROJECT_NAME=$(echo "$PROJECT_NAME" | sed 's/[[:space:]]/-/g')
+
+    ensure_envvar_present PROJECT_NAME $PROJECT_NAME
+
+    echo  -e "${BBlack}What is the local development domain?${Color_Off}"
+    echo  " Do not add protocol, but just the domain name. For clarity it is recommended to use specified domains locally."
+    read -p "Domain [$PROJECT_NAME.ld] " LOCAL_DOMAIN
+    case "$LOCAL_DOMAIN" in
+        '') LOCAL_DOMAIN="$PROJECT_NAME.ld"
+    esac
+    # Remove spaces.
+    LOCAL_DOMAIN=$(echo "$LOCAL_DOMAIN" | sed 's/[[:space:]]/./g')
+    ensure_envvar_present LOCAL_DOMAIN $LOCAL_DOMAIN
+
+    echo  -e "${BBlack}What is the local development IP address?${Color_Off}"
+    echo  "Random 10.10.0.0./16 will be generated for you if you so wish?"
+    read -p "Use the random IP address 10.10.0.0./16 [Y/n]? " LOCAL_IP
+    case "$LOCAL_IP" in
+        'n'|'N'|'no'|'NO') LOCAL_IP='127.0.0.1';;
+        *) LOCAL_IP=$( printf "10.10.%d.%d\n" "$((RANDOM % 256))" "$((RANDOM % 256))");;
+    esac
+    echo -e "${Yellow}Using IP address $LOCAL_IP.${Color_Off}"
+    ensure_envvar_present LOCAL_IP $LOCAL_IP
+
+    # 2nd param, project type.
+    TYPE=${1-'common'}
     # Suggest Skeleton cleanup only when it is relevant.
-    APP_ROOT='app/'
-    if [ ! -e "$DOCKERSYNC_FILE" ] || [ ! -e "$DOCKER_COMPOSE_FILE" ]; then
-        echo "Copying Docker compose/sync files. What is project type? "
-        echo " [0] New project, application built in ./$APP_ROOT -folder [default]"
-        #echo " [1] Old project, application built in ./$APP_ROOT -folder "
-        echo " [2] Skeleton -proejct. Drupal in drupal/ and custom code spread in src/ folder."
-        read -p "Project type: " CHOICE
+    if [ -e "$DOCKERSYNC_FILE" ] || [ -e "$DOCKER_COMPOSE_FILE" ]; then
+        echo -e "${BYellow}WARNING: There is docker-compose and/or docker-sync recipies in project root.${Color_Off}"
+        echo -e "${BYellow}If you continue your containers with their volumes ${BRed}will be destroyed.${Color_Off}"
+        echo -e "However it this does not delete code from your application root directory."
+        read -p "Continue? [y/N]" CHOICE
         case "$CHOICE" in
-            ''|0|1 ) yml_move;;
-            2 ) APP_ROOT='drupal/'; yml_move skeleton;;
-            * ) echo "ERROR: Unclear answer, exiting" && cd $CWD && exit;;
-        esac
-        echo 'APP_ROOT='$APP_ROOT >> $PROJECT_ROOT/.env
-        read -p "Use project-name based docker-sync -volumes [default]? [Y/n]" CHOICE
-        case "$CHOICE" in
-            ''|y|Y|'yes'|'YES' ) $SCRIPT_NAME rename-volumes;;
-            n|N|'no'|'NO' ) echo "Volume names will start with 'webroot-'";;
+            n|N|'no'|'NO' ) echo "Cancelled." && exit;;
         esac
     fi
+
+    echo "Setting up docker-compose and docker-sync files for project type '$TYPE'."
+    yml_move $TYPE
+
+    # Skeleton uses different folder as the main location for app code.
+    [[ "$TYPE" == "skeleton" ]] &&  APP_ROOT='drupal'
+
+    APP_ROOT=${APP_ROOT:-app}
+    ensure_envvar_present APP_ROOT $APP_ROOT
+    ensure_folders_present $APP_ROOT
+    echo -e "${Yellow}NOTE: Application root is in $APP_ROOT.${Color_Off}"
+
+    DATABASE_DUMP_STORAGE=${DATABASE_DUMP_STORAGE:-db_dumps}
+    ensure_envvar_present DATABASE_DUMP_STORAGE $DATABASE_DUMP_STORAGE
+    ensure_folders_present $DATABASE_DUMP_STORAGE
+    echo -e "${Yellow}Database dumps will appear in $DATABASE_DUMP_STORAGE.${Color_Off}"
+
+    read -p "Use project-name based docker-sync -volumes [default]? [Y/n]" CHOICE
+    case "$CHOICE" in
+        ''|y|Y|'yes'|'YES' ) $SCRIPT_NAME rename-volumes $PROJECT_NAME;;
+        *) echo "Volume names will start with 'webroot-'";;
+    esac
+
     if [[ "$(docker-compose -f $DOCKER_COMPOSE_FILE ps)" ]]; then
         echo "Turning off current container stack."
         docker-compose -f $DOCKER_COMPOSE_FILE down

--- a/docker/scripts/ld.command.rename-volumes.sh
+++ b/docker/scripts/ld.command.rename-volumes.sh
@@ -8,27 +8,27 @@ function ld_command_rename-volumes_exec() {
         echo 'Turning off docker-sync, please wait...'
         docker-sync clean
     fi
-    DEFAULT=$(basename $PROJECT_ROOT)
+    VOL_BASE_NAME=$1
     VALID=0
     while [ "$VALID" -eq "0" ]; do
-        echo "Please give me your project name [default: \"$DEFAULT\"]? "
-        read -p "Project name: " PROJECTNAME
-        if [ -z "$PROJECTNAME" ]; then
-            PROJECTNAME=$DEFAULT
+        echo "Please give me your container volume base name? "
+        read -p "Container volume base name ['$VOL_BASE_NAME']: " ANSWER
+        if [ -z "$ANSWER" ]; then
             VALID=1
-        elif [[ "$PROJECTNAME" =~ ^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$ ]]; then
+        elif [[ "$ANSWER" =~ ^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$ ]]; then
+            VOL_BASE_NAME=$ANSWER
             VALID=1
         else
-            echo -e "${Red}ERROR: Project name can contain only alphabetic characters (a-z), numbers (0-9), underscore (_) and hyphen (-).${Color_Off}"
-            echo -e "${Red}ERROR: Also the project name must not start or end with underscore or hyphen.${Color_Off}"
+            echo -e "${Red}ERROR: Volume base name can contain only alphabetic characters (a-z), numbers (0-9), underscore (_) and hyphen (-).${Color_Off}"
+            echo -e "${Red}ERROR: Volume base name must not start or end with underscore or hyphen.${Color_Off}"
             sleep 2
             echo
         fi
     done;
 
-     echo "Renaming volumes to '$PROJECTNAME' for docker-sync, please wait..."
-     replace_in_file "s/webroot-sync/$PROJECTNAME""-sync/g" $DOCKERSYNC_FILE
-     replace_in_file "s/webroot-sync/$PROJECTNAME""-sync/g" $DOCKER_COMPOSE_FILE
+     echo "Renaming volumes to '$VOL_BASE_NAME' for docker-sync, please wait..."
+     replace_in_file "s/webroot-sync/${VOL_BASE_NAME}-sync/g" $DOCKERSYNC_FILE
+     replace_in_file "s/webroot-sync/${VOL_BASE_NAME}-sync/g" $DOCKER_COMPOSE_FILE
 }
 
 #function ld_command_rename-volumes_help() {

--- a/docker/scripts/ld.command.restore.sh
+++ b/docker/scripts/ld.command.restore.sh
@@ -4,7 +4,7 @@
 # This file contains restore -command for local-docker script ld.sh.
 
 function ld_command_restore_exec() {
-    if [ ! -e "db_dumps/db-container-dump-LATEST.sql.gz" ]; then
+    if [ ! -e "$DATABASE_DUMP_STORAGE/db-container-dump-LATEST.sql.gz" ]; then
         echo -e "${Red}"
         echo "********************************************************************************************"
         echo "** Dump file missing! Create a symlin to your DB backup file:                             **"
@@ -31,8 +31,8 @@ function ld_command_restore_exec() {
     docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_DB sh -c "$RESTORE_INFO 2>/dev/null"
     echo
     echo 'Restoring db...'
-    echo -n "DB backup used: db_dumps/db-container-dump-LATEST.sql.gz => "
-    echo $(readlink db_dumps/db-container-dump-LATEST.sql.gz)
+    echo -n "DB backup used: $DATABASE_DUMP_STORAGE/db-container-dump-LATEST.sql.gz => "
+    echo $(readlink $DATABASE_DUMP_STORAGE/db-container-dump-LATEST.sql.gz)
     echo "[This may take some time...]"
     RESTORER="gunzip < /var/db_dumps/db-container-dump-LATEST.sql.gz | mysql --host "$CONTAINER_DB" -uroot -p"$MYSQL_ROOT_PASSWORD""
     docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_DB sh -c "$RESTORER 2>/dev/null"

--- a/docker/scripts/ld.command.up.sh
+++ b/docker/scripts/ld.command.up.sh
@@ -7,6 +7,7 @@ function ld_command_up_exec() {
     if is_dockersync; then
         docker-sync start
     fi
+    ensure_folders_present $DATABASE_DUMP_STORAGE
     docker-compose -f $DOCKER_COMPOSE_FILE up -d
     $SCRIPT_NAME drupal-files-folder-perms
     OK=$?

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -104,3 +104,27 @@ function_exists() {
     declare -f -F $1 > /dev/null
     return $?
 }
+
+function ensure_folders_present() {
+    for DIR in $@; do
+       if [ ! -e "$DIR" ]; then
+            mkdir -vp $DIR
+       fi
+    done
+}
+
+function ensure_envvar_present() {
+    NAME=$1
+    VAL=$2
+    if [ ! -e ".env" ]; then
+        echo -e "${Red}ERROR: File .env not present while trying to store a value into it.${Color_Off}";
+        exit;
+    fi
+    EXISTS=$(grep $NAME .env | wc -l)
+    if [ "$EXISTS" -gt "0" ]; then
+        PATTERN="s/^$NAME=.*/$NAME=$VAL/"
+        replace_in_file $PATTERN .env
+    else
+        echo "${NAME}=${VAL}" >> $PROJECT_ROOT/.env
+    fi
+}

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -20,21 +20,30 @@ is_dockersync() {
 }
 
 # Copy conf of your choosing to project root, destroy leftovers.
+# Template must be found using filename patters
+# TPL-NAME => $DOCKER_YML_STORAGE/docker-compose.TPL-NAME.yml,
+# usually: docker/docker-compose.TPL-NAME.yml
 # Usage
-#   yml_move
-#   yml_move skeleton
+#   yml_move template-name
 yml_move() {
-    MODE=${1-'common'}
-    echo "MODE: $MODE"
+    MODE=$1
+    if [ -z "$MODE" ]; then
+       echo -e "${Red}Trying to use yml files without project type.${Color_Off}"
+       exit 1
+    fi
+
     if [ -f "$DOCKER_YML_STORAGE/docker-compose.$MODE.yml" ]; then
         echo "Using $DOCKER_YML_STORAGE/docker-compose.$MODE.yml as the docker-compose recipe."
-        mv -v $DOCKER_YML_STORAGE/docker-compose.$MODE.yml ./$DOCKER_COMPOSE_FILE
-        rm -f $DOCKER_YML_STORAGE/docker-compose.*.yml
+        cp $DOCKER_YML_STORAGE/docker-compose.$MODE.yml ./$DOCKER_COMPOSE_FILE
+    else
+        echo -e "${Red} Docker-compose template file missing: $DOCKER_YML_STORAGE/docker-compose.$MODE.yml"
     fi
-    if [ -f "$DOCKER_YML_STORAGE/docker-sync.$MODE.yml" ]; then
+    # NFS template does not have docker-sync -flavor, as it uses nfs mounts for folder sharing.
+    if [ "$MODE" != "nfs" ] && [ -f "$DOCKER_YML_STORAGE/docker-sync.$MODE.yml" ]; then
         echo "Using $DOCKER_YML_STORAGE/docker-sync.$MODE.yml as the docker-sync recipe."
-        mv -v $DOCKER_YML_STORAGE/docker-sync.$MODE.yml ./$DOCKERSYNC_FILE
-        rm -f $DOCKER_YML_STORAGE/docker-sync.*.yml
+        cp $DOCKER_YML_STORAGE/docker-sync.$MODE.yml ./$DOCKERSYNC_FILE
+    else
+        echo -e "${Red} Docker-sync template file missing: $DOCKER_YML_STORAGE/docker-sync.$MODE.yml"
     fi
 }
 

--- a/ld.sh
+++ b/ld.sh
@@ -120,7 +120,7 @@ case "$ACTION" in
     if [[ -f "$FILE" ]]; then
         . $FILE
         FUNCTION="ld_command_"$ACTION"_exec"
-        function_exists $FUNCTION && $FUNCTION || echo -e "${Red}ERROR: Command not found (hook '$FUNCTION' missing for command $ACTION).${Color_Off}."
+        function_exists $FUNCTION && $FUNCTION ${@:2} || echo -e "${Red}ERROR: Command not found (hook '$FUNCTION' missing for command $ACTION).${Color_Off}."
     else
         echo -e "${Red}ERROR: Command not found (hook file missing).${Color_Off}."
     fi


### PR DESCRIPTION
Fixes #46 

Init consumes 1st sub-command parameter as project type, and fails if it does not match file templates.

Init also writes some commonly used parameters now to `.env` file (adds or replaces existing value).