### PR TITLE
Issue 45 parallel projects separate by

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,15 @@
 # General setup
-PROJECT_NAME=
+PROJECT_NAME=my-project
+LOCAL_DOMAIN=my-project.ld
 # IP address where the containers exposed ports are bind.
 # WARNING: IP addres 0.0.0.0 will bind the ports to all of your
 # laptops network interfaces - effectively allowing anyone to
 # connect to your container ports - Nginx, databases etc. alike.
 LOCAL_IP=127.0.0.1
-LOCAL_DOMAIN=my-project.ld
+
+# Some locations.
+DATABASE_DUMP_STORAGE=db_dumps
+APP_ROOT=app
 
 # Docker-compose recipe:
 COMPOSE_FILE=docker-compose.yml
@@ -50,7 +54,3 @@ CONTAINER_PORT_DB=3306
 CONTAINER_PORT_ADMINER=8080
 CONTAINER_PORT_MAILHOG=8025
 CONTAINER_PORT_VARNISH=8017
-
-# Some locations.
-DATABASE_DUMP_STORAGE=db_dumps
-APP_ROOT=app

--- a/README.md
+++ b/README.md
@@ -105,25 +105,19 @@ an error, ensure `ld.sh` has execute permission:
 
     $ chmod 0744 ld.sh
 
-Initial setup asks if you is a Skeleton based project. If you have no
-idea what does it mean, do not use it. 
+Initial setup asks if you some generic information. 
 
-    $ ./ld init # asks if you what config to use (Skeleton or not).
+    $ ./ld init
 
 If you are applying `local-docker` on a Skeleton -based project, see
 "Skeleton" -section .
 
 ### Local domains
 
-This is needed to use a local domain (ie. type something other
-than http://0.0.0.0 or http://localhost in your browser).
-
-1.  Add your desired (local) domains to `/etc/hosts`.
-
-        #######################################################
-        ##############  PROJECT NAME    #######################
-        127.0.0.1 mylocal.example.com mylocal.example.fi other.multilanguage.domain mylocal.de.example.com
-        127.0.0.1 mailhog.local
+`./ld init` sets up your local IP addresses and domains. You'll be asked
+for a local development domain among ohter things, and `local-docker`
+will write a `/etc/hosts` -record for you and maintain localhost IP
+address aliases.
 
 #### Install Drupal
 
@@ -156,13 +150,7 @@ If you are applying Local-docker on a Skeleton based project start by
 copying all things mentioned in "Start using local-docker" -section on
 top of your project repository. 
 
-When initial setup asks about Skeleton, answer `y`.
-
-    $ ./ld init
-    Copying Docker compose/sync files. What is project type?
-     [0] New project, application built in ./app -folder "
-     [2] Skeleton -project. Drupal in drupal/ and custom code in src/ folder.
-    Project type: 
+    $ ./ld init skeleton
 
 After some configuration your codebase is built, and Docker volumes
 (including volumes used by `docker-sync`) according general Skeleton
@@ -211,20 +199,17 @@ and answer some question to set up things properly.
 
 If containers are not pulles/built yet, this will do it for you. 
 
-    $ ./ld up            # or  
-    $ docker-sync start && docker-compose up -d
+    $ ./ld up
 
 #### Stop local
 
 Put local to sleep:
 
-    $ ./ld stop # or 
-    $ docker-compose stop [; docker-sync clean]
+    $ ./ld stop 
 
-Stop (ie. remove volumes with content, containers):
+Stop (ie. remove volumes unless they are persistent):
 
-    $ ./ld down # or 
-    $ docker-compose down; docker-sync clean
+    $ ./ld down
 
 Note that files sync must be started in order to start other containers,
 and it keeps 1-n pcs of containers running when it is started.
@@ -251,21 +236,23 @@ This is done automatically when you stop or destroy your containers.
 
 #### Composer, Drush, Drupal
 
-Composer, Drush or Drupal console are aliased inside `php` container. Do
-your thing:
+Composer, Drush or Drupal console are aliased inside `php` container as
+well as commands in `./ld [drush|drupal|composer]`.
 
     $ docker-compose exec php bash
     /var/www # drush status
     /var/www # composer require drupal/pathauto:^1
+    /var/www # drupal ce --exclude-config-hash --directory=../config/sync
 
-Composer commands can be launched from your host (but executed inside
-container):
+These commands are funcionality-wise the same:
 
+    $ ./ld drush status
     $ ./ld composer require drupal/pathauto:^1
+    $ ./ld drupal ce --exclude-config-hash --directory=../config/sync
 
-Another way is run one-off commands in `php` -container:
+You can also execute commands directly in the shell:
 
-    $ docker-compose exec php bash -c "drush status"
+    $ docker-compose exec php bash -c "drush status" # OR $ ./ld drush status
 
 #### Compile CSS
 
@@ -314,16 +301,6 @@ alias to your shell startup files. In order to not interfere with `/usr/bin/ld`,
 
 Then, you can use `lld` instead of `./ld` or `./ld.sh`
 
-### Launch a new project
-
-`./ld init` creates a drupal-project for you out-of-the-box (this will
-take a few minutes). If you already have a `drupal/composer.json` file
-you should not do that, but rather execute composer install:
-
-    $ ./ld composer install
-    # OR
-    $ docker-compose exec php bash -c "composer install"
-
 ## Projects in parallel?
 
 Docker volumes are using volume names from `docker-composer.yml` (see
@@ -338,8 +315,10 @@ root-level key `volumes`). If you collapse with other projects:
    
 Another thing that may be needed is changing exposed ports. As an
 example `nginx` exposes port 80 and only one project can use the port at
-a time. You can change exposed ports in `.env` file, look for variable
-names starting `CONTAINER_PORT_`.
+a time in the same IP address. Separating IP addresses per project
+should be enough, but in case you bump into weird issues you can always 
+change exposed ports in `.env` file, look for variable names starting
+`CONTAINER_PORT_`.
 
 ### Local ports
 

--- a/docker/scripts/ld.command.configure-network-down.sh
+++ b/docker/scripts/ld.command.configure-network-down.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# File
+#
+# This file contains configure-network-down -command for local-docker script ld.sh.
+# Internal use only.
+
+function ld_command_configure-network-down_exec() {
+    LOCAL_IP=${LOCAL_IP:-127.0.0.1}
+    SUDO_REQUESTED=
+
+    if [ "$LOCAL_IP" != "127.0.0.1" ]; then
+        IP_ALIAS_SET=$(ifconfig lo0 | grep -c $LOCAL_IP)
+        if ((  "$IP_ALIAS_SET" > "0" )); then
+            echo -e "${Yellow}Removing an IP alias may require your password. Your password is not stored anywhere by local-docker.${Color_Off}"
+            echo -e "${Yellow}Removing an IP alias from your loopback network interface.${Color_Off}"
+            sudo ifconfig lo0 delete $LOCAL_IP
+        fi
+    fi
+}
+
+#function ld_command_configure-network-down_help() {
+#    echo "Brings containers up with building step if necessary (starts docker-sync)"
+#}

--- a/docker/scripts/ld.command.configure-network.sh
+++ b/docker/scripts/ld.command.configure-network.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# File
+#
+# This file contains configure-network -command for local-docker script ld.sh.
+# Internal use only.
+
+function ld_command_configure-network_exec() {
+    LOCAL_IP=${LOCAL_IP:-127.0.0.1}
+    LOCAL_DOMAIN=${LOCAL_DOMAIN:-localhost}
+    SUDO_REQUESTED=
+
+    if [ "$LOCAL_IP" == "127.0.0.1" ]; then
+        echo -e "${Yellow}Project is using IP address 127.0.0.1, so IP alias is not needed.${Color_Off}"
+    else
+        IP_ALIAS_SET=$(ifconfig lo0 | grep -c $LOCAL_IP)
+        if [  "$IP_ALIAS_SET" == "0" ]; then
+            echo -e "${Yellow}Configuring networking may require your password. Your password is not stored anywhere by local-docker.${Color_Off}"
+            echo -e "${Yellow}Adding an IP alias to your loopback network interface.${Color_Off}"
+            echo -e "${Yellow}Alias will be removed when you put this project down, or reboot your computer.${Color_Off}"
+            SUDO_REQUESTED=1
+            sudo ifconfig lo0 alias $LOCAL_IP
+        else
+            echo -e "${Green}IP alias $LOCAL_IP is already set.${Color_Off}"
+        fi
+    fi
+
+    DOMAIN_SET=$(egrep -e $LOCAL_IP'\s*([a-z0-9\.-]*\s?\s*)*('$LOCAL_DOMAIN')' /etc/hosts)
+    if [ "$LOCAL_DOMAIN" != "localhost" ]; then
+        if [ -z "$DOMAIN_SET" ]; then
+            echo -e "${Yellow}Adding domain $LOCAL_DOMAIN to your hosts file to poin to $LOCAL_IP.${Color_Off}"
+            echo -e "${BYellow}NOTE: This DNS record is not removed automatically.${Color_Off}"
+            if [ -z "$SUDO_REQUESTED" ]; then
+                echo -e "${Yellow}Configuring networking may require your password. Your password is not stored anywhere by local-docker.${Color_Off}"
+                echo
+            fi
+            sudo bash -c "echo && echo '############  Project (local-docker): $PROJECT_NAME   ##############' >> /etc/hosts"
+            sudo bash -c "echo '$LOCAL_IP      $LOCAL_DOMAIN' >> /etc/hosts"
+        else
+            echo -e "${Green}Domain $LOCAL_DOMAIN is already configured.${Color_Off}"
+        fi
+    fi
+}
+
+#function ld_command_configure-network_help() {
+#    echo "Brings containers up with building step if necessary (starts docker-sync)"
+#}

--- a/docker/scripts/ld.command.down.sh
+++ b/docker/scripts/ld.command.down.sh
@@ -14,6 +14,7 @@ function ld_command_down_exec() {
     if is_dockersync; then
         docker-sync clean
     fi
+    $SCRIPT_NAME configure-network-down
 }
 
 function ld_command_down_help() {

--- a/docker/scripts/ld.command.dump.sh
+++ b/docker/scripts/ld.command.dump.sh
@@ -11,16 +11,16 @@ function ld_command_dump_exec() {
         exit 1
     fi
 
-    echo "${Yellow}Using datestamp: $DATE${Color_Off}"
+    echo -e "${Yellow}Using datestamp: $DATE${Color_Off}"
     DUMPER="mysqldump --host "$CONTAINER_DB" -uroot -p"$MYSQL_ROOT_PASSWORD" --all-databases --lock-all-tables --compress --flush-logs --flush-privileges  --dump-date --tz-utc --verbose"
     docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_DB sh -c "$DUMPER  2>/dev/null | gzip --fast -f > /var/db_dumps/db-container-dump-$DATE.sql.gz"
     cd $PROJECT_ROOT/$DATABASE_DUMP_STORAGE
     ln -sf db-container-dump-$DATE.sql.gz db-container-dump-LATEST.sql.gz
     cd $PROJECT_ROOT
-    echo "DB backup in db_dumps/db-container-dump-$DATE.sql.gz"
-    echo "DB backup symlink: db_dumps/db-container-dump-LATEST.sql.gz"
+    echo "DB backup in $DATABASE_DUMP_STORAGE/db-container-dump-$DATE.sql.gz"
+    echo "DB backup symlink: $DATABASE_DUMP_STORAGE/db-container-dump-LATEST.sql.gz"
 }
 
 function ld_command_dump_help() {
-    echo "Backup databases to db_dump -folder"
+    echo "Backup databases to $DATABASE_DUMP_STORAGE -folder"
 }

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -28,8 +28,8 @@ function ld_command_init_exec() {
 
     ensure_envvar_present PROJECT_NAME $PROJECT_NAME
 
-    echo  -e "${BBlack}What is the local development domain?${Color_Off}"
-    echo  " Do not add protocol, but just the domain name. For clarity it is recommended to use specified domains locally."
+    echo -e "${BBlack}What is the local development domain?${Color_Off}"
+    echo " Do not add protocol, but just the domain name. For clarity it is recommended to use specified domains locally."
     read -p "Domain [$PROJECT_NAME.ld] " LOCAL_DOMAIN
     case "$LOCAL_DOMAIN" in
         '') LOCAL_DOMAIN="$PROJECT_NAME.ld"
@@ -142,7 +142,7 @@ function ld_command_init_exec() {
         exit 1
     fi
     echo
-    echo echo -e "${Green}Project created to ./$APP_ROOT -folder (/var/www in containers).${Color_Off}"
+    echo -e "${Green}Project created to ./$APP_ROOT -folder (/var/www in containers).${Color_Off}"
     # This must be run after composer install.
     $SCRIPT_NAME drupal-structure-fix
     $SCRIPT_NAME drupal-files-folder-perms
@@ -153,7 +153,7 @@ function ld_command_init_exec() {
     echo
     echo -e "${Green}Codebase ready!!${Color_Off}"
     echo
-    echo-e "${Yellow}NOTE: Once Drupal is installed, you should remove write perms in sites/default -folder:${Color_Off}"
+    echo -e "${Yellow}NOTE: Once Drupal is installed, you should remove write perms in sites/default -folder:${Color_Off}"
     echo "docker-compose -f $DOCKER_COMPOSE_FILE exec php bash -c 'chmod -v 0755 web/sites/default'"
     echo "docker-compose -f $DOCKER_COMPOSE_FILE exec php bash -c 'chmod -v 0644 web/sites/default/settings.php'"
     echo "With these changes you can edit settings.php from host, but Drupal is happy not to be allowed to write there."

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -38,12 +38,12 @@ function ld_command_init_exec() {
     LOCAL_DOMAIN=$(echo "$LOCAL_DOMAIN" | sed 's/[[:space:]]/./g')
     ensure_envvar_present LOCAL_DOMAIN $LOCAL_DOMAIN
 
-    echo  -e "${BBlack}What is the local development IP address?${Color_Off}"
-    echo  "Random 10.10.0.0./16 will be generated for you if you so wish?"
-    read -p "Use the random IP address 10.10.0.0./16 [Y/n]? " LOCAL_IP
+    echo -e "${BBlack}What is the local development IP address?${Color_Off}"
+    echo "Random 127.0.0.0./16 will be generated for you if you so wish?"
+    read -p "Use the random IP address 127.0.0.0./16 [Y/n]? " LOCAL_IP
     case "$LOCAL_IP" in
         'n'|'N'|'no'|'NO') LOCAL_IP='127.0.0.1';;
-        *) LOCAL_IP=$( printf "10.10.%d.%d\n" "$((RANDOM % 256))" "$((RANDOM % 256))");;
+        *) LAST=$((RANDOM % 240 + 3 )) && LOCAL_IP=$( printf "127.0.%d.%d\n" "$((RANDOM % 256))" "$LAST");;
     esac
     echo -e "${Yellow}Using IP address $LOCAL_IP.${Color_Off}"
     ensure_envvar_present LOCAL_IP $LOCAL_IP

--- a/docker/scripts/ld.command.up.sh
+++ b/docker/scripts/ld.command.up.sh
@@ -23,7 +23,7 @@ function ld_command_up_exec() {
     CONN=$?
 
     if [ "$CONN" -ne 0 ]; then
-        echo "${Red}Oww... DB container is not up, even after a few retries.${Color_Off}"
+        echo -e "${Red}Oww... DB container is not up, even after a few retries.${Color_Off}"
         cd $CWD
         exit 1
     fi
@@ -33,7 +33,7 @@ function ld_command_up_exec() {
     docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_DB sh -c "$RESTORE_INFO 2>/dev/null"
     echo 'Current database users:'
     docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_DB sh -c "$USERS 2>/dev/null"
-    echo "${Yellow}NOTE: No database dump restored.${Color_Off}"
+    echo -e "${Yellow}NOTE: No database dump restored.${Color_Off}"
     echo 'In case you need to do that (Drupal DB is gone?),'
     echo '1) check your symlink target in db_dumps/db-container-dump-LATEST.sql.gz'
     echo '2) execute the following command:'

--- a/docker/scripts/ld.command.up.sh
+++ b/docker/scripts/ld.command.up.sh
@@ -4,6 +4,9 @@
 # This file contains up -command for local-docker script ld.sh.
 
 function ld_command_up_exec() {
+
+    $SCRIPT_NAME configure-network
+
     if is_dockersync; then
         docker-sync start
     fi


### PR DESCRIPTION
Fixes #45 

This PR adds network configuration tools to `./ld`, and configures IP addresses for projects. Used IP address space is `127.0.0.0/16`, random IP address. 

In the essence binding Docker's exposed ports to a non localhost -IP allows users to run projects in parallel, for example one webserver in `127.0.100.10:80` and another in `127.0.55.66:80`