### PR TITLE
Return value instead of exiting if .env not there

### DIFF
--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -97,7 +97,7 @@ import_root_env() {
         export $(grep -v '^#' $ENV_FILE | xargs)
         return 0
     fi
-    exit 1
+    return 1
 }
 
 function_exists() {


### PR DESCRIPTION
This fixes the happily dying `./ld` if `.env` file is not present.