### PR TITLE
Issue 52: Make PHP version behind env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ LOCAL_DOMAIN=my-project.ld
 # laptops network interfaces - effectively allowing anyone to
 # connect to your container ports - Nginx, databases etc. alike.
 LOCAL_IP=127.0.0.1
+# Do not use PHP_VERSION -name, it collides with PHP intenrals.
+# Valid options are 7.1, 7.2 (see build file paths in docker/build/php).
+PROJECT_PHP_VERSION=7.2
 
 # Some locations.
 DATABASE_DUMP_STORAGE=db_dumps

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -27,7 +27,7 @@ services:
     # Available builds: https://hub.docker.com/r/xoxoxo/php-container/tags
     # Custom build contains sendmail_path -fix for Mailhog and OPTION to add
     # overrides (per project) to other PHP config.
-    build: ./docker/build/php/7.2
+    build: ./docker/build/php/${PROJECT_PHP_VERSION}
     volumes:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
@@ -38,7 +38,7 @@ services:
 
   composer:
     # Run `composer install` during startup.
-    build: ./docker/build/php/7.2
+    build: ./docker/build/php/${PROJECT_PHP_VERSION}
     volumes:
       # This share gets writes from within the container by Composer.
       # :nocopy must be used with docker-sync

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -35,7 +35,7 @@ services:
     # Available builds: https://hub.docker.com/r/xoxoxo/php-container/tags
     # Custom build contains sendmail_path -fix for Mailhog and OPTION to add
     # overrides (per project) to other PHP config.
-    build: ./docker/build/php/7.2
+    build: ./docker/build/php/${PROJECT_PHP_VERSION}
     volumes:
       # :nocopy must be used with docker-sync
       - nfsmount_app:/var/www:nocopy
@@ -45,7 +45,7 @@ services:
 
   composer:
     # Run `composer install` during startup.
-    build: ./docker/build/php/7.2
+    build: ./docker/build/php/${PROJECT_PHP_VERSION}
     volumes:
       - nfsmount_app:/var/www:nocopy
     env_file:

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -25,7 +25,7 @@ services:
     # Available builds: https://hub.docker.com/r/xoxoxo/php-container/tags
     # Custom build contains sendmail_path -fix for Mailhog and OPTION to add
     # overrides (per project) to other PHP config.
-    build: ./docker/build/php/7.2
+    build: ./docker/build/php/${PROJECT_PHP_VERSION}
     volumes:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
@@ -40,7 +40,7 @@ services:
 
   composer:
     # Run `composer install` during startup.
-    build: ./docker/build/php/7.2
+    build: ./docker/build/php/${PROJECT_PHP_VERSION}
     volumes:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml


### PR DESCRIPTION
Environment variable introduced in .env.example controls what build file path is used with PHP containers (php, composer).

`PROJECT_PHP_VERSION=7.1|7.2`

(Note: PHP_VERSION would override the regular version variable by PHP itself.)