### PR TITLE
Issue 53 toggle xdebug via command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,11 @@ MYSQL_PASSWORD=drupal
 # $ ./ld rebuild (re-syncs also sync-containers, takes a few minutes)
 # $ docker-compose up -d --build (faster)
 PHP_MEMORY_LIMIT=1536M
+
+# Xdebug.
+PHP_XDEBUG_REMOTE_ENABLE=1
 PHP_XDEBUG_REMOTE_HOST=host.docker.internal
 PHP_XDEBUG_REMOTE_PORT=9010
-PHP_XDEBUG_REMOTE_ENABLE=1
 #PHP_XDEBUG_REMOTE_LOG=/var/log/xdebug.log
 
 # Some container names used in ld.sh..

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -34,6 +34,8 @@ services:
       - webroot-sync-core:/var/www:nocopy
     env_file:
       - .env
+    environment:
+        XDEBUG_CONFIG: "remote_enable=${PHP_XDEBUG_REMOTE_ENABLE}"
     working_dir: /var/www
 
   composer:

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -41,6 +41,8 @@ services:
       - nfsmount_app:/var/www:nocopy
     env_file:
       - .env
+    environment:
+        XDEBUG_CONFIG: "remote_enable=${PHP_XDEBUG_REMOTE_ENABLE}"
     working_dir: /var/www
 
   composer:

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -36,6 +36,8 @@ services:
       - webroot-sync-core:/var/www:nocopy
     env_file:
       - .env
+    environment:
+        XDEBUG_CONFIG: "remote_enable=${PHP_XDEBUG_REMOTE_ENABLE}"
     working_dir: /var/www
 
   composer:

--- a/docker/scripts/ld.command.xdebug.sh
+++ b/docker/scripts/ld.command.xdebug.sh
@@ -4,6 +4,11 @@
 # This file contains stop -command for local-docker script ld.sh.
 
 function ld_command_xdebug_exec() {
+    if [ -z "$CONTAINER_PHP" ]; then
+        echo -e "${Red}ERROR: PHP container name is missing.${Color_Off}"
+        echo -e "${Red}Ensure you have variable 'CONTAINER_PHP' set in configuration.${Color_Off}"
+        exit 1
+    fi
     case "$1" in
         '1'|'on') ensure_envvar_present PHP_XDEBUG_REMOTE_ENABLE 1; sleep 1; docker-compose -f $DOCKER_COMPOSE_FILE up -d php && $SCRIPT_NAME xdebug;;
         '0'|'off') ensure_envvar_present PHP_XDEBUG_REMOTE_ENABLE 0; docker-compose -f $DOCKER_COMPOSE_FILE up -d php && $SCRIPT_NAME xdebug;;

--- a/docker/scripts/ld.command.xdebug.sh
+++ b/docker/scripts/ld.command.xdebug.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# File
+#
+# This file contains stop -command for local-docker script ld.sh.
+
+function ld_command_xdebug_exec() {
+    case "$1" in
+        '1'|'on') ensure_envvar_present PHP_XDEBUG_REMOTE_ENABLE 1; sleep 1; docker-compose -f $DOCKER_COMPOSE_FILE up -d php && $SCRIPT_NAME xdebug;;
+        '0'|'off') ensure_envvar_present PHP_XDEBUG_REMOTE_ENABLE 0; docker-compose -f $DOCKER_COMPOSE_FILE up -d php && $SCRIPT_NAME xdebug;;
+        *) docker-compose -f $DOCKER_COMPOSE_FILE exec php bash -c 'echo -n "Xdebug is: "; php -i | grep xdebug.remote_enable |tr -s " => " "|" | cut -d "|" -f2';;
+    esac
+
+}
+
+function ld_command_xdebug_help() {
+    echo "Set or get Xdebug status (enabled, disabled). Optional paremeter to toggle value ['on'|1|'off'|0], omit to get current value."
+}

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -88,6 +88,8 @@ replace_in_file () {
     sed --version >/dev/null 2>&1 && sed -i -- "$@" || sed -i "" "$@"
 }
 
+# Import all environment variables from .env -file.
+# This should be done every time after vars are updated.
 import_root_env() {
     ENV_FILE="$PROJECT_ROOT/.env"
 
@@ -127,4 +129,6 @@ function ensure_envvar_present() {
     else
         echo "${NAME}=${VAL}" >> $PROJECT_ROOT/.env
     fi
+    # Re-import all vars to take effect in host and container shell, too.
+    import_root_env
 }


### PR DESCRIPTION
Fixes #53

Add Xdebug toggler command. Improve environment variable changes - when edited refresh what ever is in `.env` -file.
`./ld xdebug` reads what is xdebug status
`./ld xdebug 1|0` sets the value

