### PR TITLE
Issue 39 add filepath argument to restore command

### DIFF
--- a/docker/scripts/ld.command.restore.sh
+++ b/docker/scripts/ld.command.restore.sh
@@ -4,37 +4,46 @@
 # This file contains restore -command for local-docker script ld.sh.
 
 function ld_command_restore_exec() {
-    if [ ! -e "$DATABASE_DUMP_STORAGE/db-container-dump-LATEST.sql.gz" ]; then
-        echo -e "${Red}"
-        echo "********************************************************************************************"
-        echo "** Dump file missing! Create a symlin to your DB backup file:                             **"
-        echo "** ln -s PATH/TO/GZIPPED/MYSQLDUMP/FILE.sql.gz ./db_dumps/db-container-dump-LATEST.sql.gz **"
-        echo "********************************************************************************************"
-        echo -e "${Color_Off}"
+    TARGET_FILE_NAME=${1:-db-container-dump-LATEST.sql.gz}
+    if [ ! -e "$DATABASE_DUMP_STORAGE/$TARGET_FILE_NAME" ]; then
+        if [ -z "$1" ]; then
+            echo -e "${Red}"
+            echo "********************************************************************************************"
+            echo "** Dump file missing! Create a symlin to your DB backup file:                             **"
+            echo "** ln -s PATH/TO/GZIPPED/MYSQLDUMP/FILE.sql.gz ./$DATABASE_DUMP_STORAGE/$TARGET_FILE_NAME **"
+            echo "********************************************************************************************"
+            echo -e "${Color_Off}"
+        else
+            echo -e "${Red}ERROR: File $DATABASE_DUMP_STORAGE/$TARGET_FILE_NAME does not exists${Color_Off}"
+        fi
         cd $CWD
         exit 1
+    fi
+    INFO=$(file -b $DATABASE_DUMP_STORAGE/$TARGET_FILE_NAME | cut -d' ' -f1)
+    if [ "$INFO" != "gzip" ]; then
+        echo -e "${Red}ERROR: File $DATABASE_DUMP_STORAGE/$TARGET_FILE_NAME type is not gzip${Color_Off}"
+        cd $CWD
+        exit 3
     fi
 
     db_connect
     CONN=$?
 
     if [ "$CONN" -ne 0 ]; then
-        echo -e "${Red}ERROR: DB container is not up, even after a few retries. Exiting..${Color_Off}."
+        echo -e "${Red}ERROR: DB container is not up, even after a few retries.${Color_Off}."
         cd $CWD
         exit 2
     fi
 
-    echo "Restoring state with DB dump."
+    echo -e "${Yellow}Restoring db from:\n $DATABASE_DUMP_STORAGE/$TARGET_FILE_NAME${Color_Off}"
+    echo "This may take some time."
 
     echo
     echo -e "${Yellow}Databases before the restore:${Color_Off}"
     docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_DB sh -c "$RESTORE_INFO 2>/dev/null"
     echo
-    echo 'Restoring db...'
-    echo -n "DB backup used: $DATABASE_DUMP_STORAGE/db-container-dump-LATEST.sql.gz => "
-    echo $(readlink $DATABASE_DUMP_STORAGE/db-container-dump-LATEST.sql.gz)
-    echo "[This may take some time...]"
     RESTORER="gunzip < /var/db_dumps/db-container-dump-LATEST.sql.gz | mysql --host "$CONTAINER_DB" -uroot -p"$MYSQL_ROOT_PASSWORD""
+    echo "Please wait..."
     docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_DB sh -c "$RESTORER 2>/dev/null"
     echo
     echo -e "${Yellow}Databases after the restore${Color_Off}"
@@ -44,5 +53,5 @@ function ld_command_restore_exec() {
   }
 
 function ld_command_restore_help() {
-    echo "Import latest db. Database container must be running."
+    echo "Import latest db. Optionally provide file name. Dump file must be located in $DATABASE_DUMP_STORAGE -folder."
 }

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -48,7 +48,7 @@ yml_move() {
 }
 
 db_connect() {
-    CONTAINER_DB_ID=$(find_container db)
+    CONTAINER_DB_ID=$(find_container $CONTAINER_DB)
     RESPONSE=0
     ROUND=0
     ROUNDS_MAX=30


### PR DESCRIPTION
Fixes #39 

Add optional filename -argumetn to restore command. File still must be inside `$DATABASE_DUMP_STORAGE` -folder (`db_dump` by default).