### PR TITLE
Issue #69: Adjust sites-folder perms

### DIFF
--- a/docker/scripts/ld.command.drupal-files-folder-perms.sh
+++ b/docker/scripts/ld.command.drupal-files-folder-perms.sh
@@ -16,9 +16,9 @@ function ld_command_drupal-files-folder-perms_exec() {
     fi
     # Can't figure out how to print msg. with quotes so that it also
     # works as a command string.
-    COMM="docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_PHP bash -c 'chown -R www-data:www-data /var/www/web/sites/*/files'"
+    COMM="docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_PHP bash -c 'chown -R www-data:root /var/www/web/sites'"
     echo -e "${Cyan}Next: $COMM${Color_Off}"
-    docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_PHP bash -c "chown -R www-data:www-data /var/www/web/sites/*/files"
+    docker-compose -f $DOCKER_COMPOSE_FILE exec $CONTAINER_PHP bash -c "chown -R www-data:root /var/www/web/sites"
 }
 
 function ld_command_drupal-files-folder-perms_help() {


### PR DESCRIPTION
Container files are owned gby root, but php runs (and needs to be able
to create+modify files) as www-data. Tests will be run as www-data.
This allows shell actions (as root) and php process modify files equally
inside sites-folder.

Fixes #69 