### PR TITLE
Issue 68: Add Drush default URI to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@
 # General setup
 PROJECT_NAME=my-project
 LOCAL_DOMAIN=my-project.ld
+DRUSH_OPTIONS_URI=http://www.my-project.ld
 
 # IP address where the containers exposed ports are bind.
 # WARNING: IP addres 0.0.0.0 will bind the ports to all of your

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -51,6 +51,7 @@ function ld_command_init_exec() {
     # Remove spaces.
     LOCAL_DOMAIN=$(echo "$LOCAL_DOMAIN" | sed 's/[[:space:]]/./g')
     ensure_envvar_present LOCAL_DOMAIN $LOCAL_DOMAIN
+    ensure_envvar_present DRUSH_OPTIONS_URI "http://www."$LOCAL_DOMAIN
 
     echo -e "${BBlack}What is the local development IP address?${Color_Off}"
     echo "Random 127.0.0.0./16 will be generated for you if you so wish?"


### PR DESCRIPTION
on `./ld init` configure also DRUSH_OPTIONS_URI value in `.env` file.