### PR TITLE
Move functionality to functions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ COMPOSE_FILE=docker-compose.yml
 # Some container names used in ld.sh..
 CONTAINER_DB=db
 CONTAINER_PHP=php
+CONTAINER_NGINX=nginx
 
 # Exposed container ports.
 CONTAINER_PORT_WEB=80

--- a/docker/scripts/ld.command.run-tests.sh
+++ b/docker/scripts/ld.command.run-tests.sh
@@ -15,7 +15,7 @@ function ld_command_run-tests_exec() {
         exit 1
     fi
     TESTS=${@}
-    SUB_COMM="/bin/su -s /bin/bash www-data -c 'test -f  web/core/scripts/run-tests.sh && php web/core/scripts/run-tests.sh --verbose --non-html --color ${TESTS} '"
+    SUB_COMM="/bin/su -s /bin/bash www-data -c 'test -f  web/core/scripts/run-tests.sh && php web/core/scripts/run-tests.sh --verbose --non-html --url http://${CONTAINER_NGINX:-nginx} --color ${TESTS} '"
     echo -e "${Cyan}Next: docker-compose exec ${CONTAINER_PHP} bash -c \"${SUB_COMM}\"${Color_Off}"
     docker-compose exec ${CONTAINER_PHP} bash -c "${SUB_COMM}"
 }

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -102,7 +102,28 @@ import_root_env() {
     return 1
 }
 
-function_exists() {
+# Copy .env.example to .env, display user the contents of it (to review).
+
+function create_root_env() {
+  echo -e "${Yellow}Copying .env.example -file => ${BYellow}.env${Yellow}. ${Color_Off}"
+  sleep 2
+  cp -f ./.env.example ./.env
+  echo  -e "${Yellow}Please review your ${BYellow}.env${Yellow} file: ${Color_Off}"
+  echo
+  echo -e "${BIWhite}========  START OF .env =========${Color_Off}"
+  sleep 1
+  cat ./.env
+  echo -e "${BIWhite}========  END OF .env =========${Color_Off}"
+  echo
+  read -p "Does this look okay? [Y/n] " CHOICE
+  case "$CHOICE" in
+    ''|y|Y|'yes'|'YES' ) import_root_env && echo -e "${Green}Cool, let's continue!${Color_Off}" & echo ;;
+    n|N|'no'|'NO' ) echo -e "Ok, we'll stop here. ${BYellow}Please edit .env file manually, and then start over.${Color_Off}" && exit 1 ;;
+    * ) echo -e "${BRed}ERROR: Unclear answer, exiting.${Color_Off}" && cd $CWD && exit 2;;
+  esac
+}
+
+function function_exists() {
     declare -f -F $1 > /dev/null
     return $?
 }

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -3,7 +3,7 @@
 #
 # This file contains functions for local-docker script ld.sh.
 
-find_container() {
+function find_container() {
     if [ -z "$1" ]; then
         echo -e "${Red}ERROR: Trying to locate a container with empty name.${Color_Off}"
         return 1
@@ -15,7 +15,7 @@ find_container() {
     fi
 }
 
-is_dockersync() {
+function is_dockersync() {
     [ ! -z "$(which docker-sync)" ] && [ -f "$PROJECT_ROOT/$DOCKERSYNC_FILE" ]
 }
 
@@ -25,7 +25,7 @@ is_dockersync() {
 # usually: docker/docker-compose.TPL-NAME.yml
 # Usage
 #   yml_move template-name
-yml_move() {
+function yml_move() {
     MODE=$1
     if [ -z "$MODE" ]; then
        echo -e "${Red}Trying to use yml files without project type.${Color_Off}"
@@ -47,7 +47,7 @@ yml_move() {
     fi
 }
 
-db_connect() {
+function db_connect() {
     CONTAINER_DB_ID=$(find_container $CONTAINER_DB)
     RESPONSE=0
     ROUND=0
@@ -84,13 +84,13 @@ db_connect() {
 
 # Cross-OS way to do in-place find-and-replace with sed.
 # Use: replace_in_file PATTERN FILENAME
-replace_in_file () {
+function replace_in_file () {
     sed --version >/dev/null 2>&1 && sed -i -- "$@" || sed -i "" "$@"
 }
 
 # Import all environment variables from .env -file.
 # This should be done every time after vars are updated.
-import_root_env() {
+function import_root_env() {
     ENV_FILE="$PROJECT_ROOT/.env"
 
     if [ -f "$ENV_FILE" ]; then

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -132,3 +132,14 @@ function ensure_envvar_present() {
     # Re-import all vars to take effect in host and container shell, too.
     import_root_env
 }
+
+function osx_version() {
+  VERSION_LONG=$(defaults read loginwindow SystemVersionStampAsString)
+  VERION_SHORT=$(echo $VERSION_LONG | cut -d'.' -f1 -f2)
+  if [ ! -z "$VERION_SHORT" ]; then
+    echo $VERION_SHORT;
+    return;
+  fi
+
+  return 1;
+}

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -143,3 +143,25 @@ function osx_version() {
 
   return 1;
 }
+
+# Check base requirements to run local-docker.
+# Some shells have built-in "which" (zsh), some use the BSD which (bash, sh)
+# and they behave differently. Trying to catch all the flavors and behaviours here.
+function required_binaries_check() {
+
+  if [ ! -z "$(which docker | grep 'not found')" ] ||
+      [ "$(which -s docker && echo $?)" -ne "0" ] ; then
+    exit 1
+  fi
+
+  if [ ! -z "$(which docker-compose | grep 'not found')" ] ||
+      [ "$(which -s docker-compose && echo $?)" -ne "0" ] ; then
+    exit 2
+  fi
+
+  if [ ! -z "$(which git | grep 'not found')" ] ||
+      [ "$(which -s git && echo $?)" -ne "0" ] ; then
+    exit 3
+  fi
+
+}

--- a/ld.sh
+++ b/ld.sh
@@ -15,6 +15,13 @@ cd $PROJECT_ROOT
 # Get functions.
 . ./docker/scripts/ld.functions.sh
 
+required_binaries_check
+case "$?" in
+  1|"1") cd $CWD && echo -e "${Red}Docker is not running. Docker is required to use local-docker.${Color_Off}" && exit 1 ;;
+  2|"2") cd $CWD && echo -e "${Red}Docker Compose was not found. It is required to use local-docker.${Color_Off}" && exit 1 ;;
+  3|"3") cd $CWD && echo -e "${Red}Git was not found. It is required to use local-docker.${Color_Off}" && exit 1 ;;
+esac
+
 # 1st param, The Command.
 ACTION=${1-'help'}
 
@@ -80,12 +87,6 @@ if [ ! -f "$DOCKER_COMPOSE_FILE" ]; then
         echo "Starting to initialise local-docker, please wait..."
         $SCRIPT_NAME init
     fi
-fi
-
-if [ -z "$(which docker)" ]; then
-  echo -e "${Red}Docker is not running. Docker is required to use local-docker.${Color_Off}"
-  cd $CWD
-  exit 1
 fi
 
 case "$ACTION" in


### PR DESCRIPTION
- move .env / .env.example file checks and handling to functions
- add os-version detector function
- fix `./ld run-tests` -command, was missign `--url` -parameter pointing to Nginx container (to NOT use `localhost`, which simply does not work in containers)