### PR TITLE
Simplify init process

### DIFF
--- a/docker/scripts/ld.command.rename-volumes.sh
+++ b/docker/scripts/ld.command.rename-volumes.sh
@@ -4,10 +4,6 @@
 # This file contains rename-volumes -command for local-docker script ld.sh.
 
 function ld_command_rename-volumes_exec() {
-    if is_dockersync; then
-        echo 'Turning off docker-sync, please wait...'
-        docker-sync clean
-    fi
     VOL_BASE_NAME=$1
     VALID=0
     while [ "$VALID" -eq "0" ]; do
@@ -25,6 +21,11 @@ function ld_command_rename-volumes_exec() {
             echo
         fi
     done;
+
+    if is_dockersync; then
+        echo 'Turning off docker-sync, please wait...'
+        docker-sync clean
+    fi
 
      echo "Renaming volumes to '$VOL_BASE_NAME' for docker-sync, please wait..."
      replace_in_file "s/webroot-sync/${VOL_BASE_NAME}-sync/g" $DOCKERSYNC_FILE

--- a/docker/scripts/ld.command.rename-volumes.sh
+++ b/docker/scripts/ld.command.rename-volumes.sh
@@ -11,7 +11,7 @@ function ld_command_rename-volumes_exec() {
     VOL_BASE_NAME=$1
     VALID=0
     while [ "$VALID" -eq "0" ]; do
-        echo "Please give me your container volume base name? "
+        echo -e "${BBlack}==  Container volume base name ==${Color_Off}"
         read -p "Container volume base name ['$VOL_BASE_NAME']: " ANSWER
         if [ -z "$ANSWER" ]; then
             VALID=1
@@ -19,7 +19,7 @@ function ld_command_rename-volumes_exec() {
             VOL_BASE_NAME=$ANSWER
             VALID=1
         else
-            echo -e "${Red}ERROR: Volume base name can contain only alphabetic characters (a-z), numbers (0-9), underscore (_) and hyphen (-).${Color_Off}"
+            echo -e "${Red}ERROR: Volume base name can contain only alphabetic characters (a-z), numbers (0-9), underscore (_) and hyphen (-) and start and end with alphabetic characters or numbers.${Color_Off}"
             echo -e "${Red}ERROR: Volume base name must not start or end with underscore or hyphen.${Color_Off}"
             sleep 2
             echo

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -149,6 +149,7 @@ function ensure_envvar_present() {
     fi
     # Re-import all vars to take effect in host and container shell, too.
     import_root_env
+    return $?
 }
 
 function osx_version() {

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -142,7 +142,7 @@ function ensure_envvar_present() {
     fi
     EXISTS=$(grep $NAME .env | wc -l)
     if [ "$EXISTS" -gt "0" ]; then
-        PATTERN="s/^$NAME=.*/$NAME=$VAL/"
+        PATTERN="s|^$NAME=.*|$NAME=$VAL|"
         replace_in_file $PATTERN .env
     else
         echo "${NAME}=${VAL}" >> $PROJECT_ROOT/.env

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -31,14 +31,12 @@ function yml_move() {
     fi
 
     if [ -f "$DOCKER_YML_STORAGE/docker-compose.$MODE.yml" ]; then
-        echo -e "${Yellow}Using $DOCKER_YML_STORAGE/docker-compose.$MODE.yml as the docker-compose recipe.${Color_Off}"
         cp $DOCKER_YML_STORAGE/docker-compose.$MODE.yml ./$DOCKER_COMPOSE_FILE
     else
         echo -e "${Red} Docker-compose template file missing: $DOCKER_YML_STORAGE/docker-compose.$MODE.yml"
     fi
     # NFS template does not have docker-sync -flavor, as it uses nfs mounts for folder sharing.
     if [ "$MODE" != "nfs" ] && [ -f "$DOCKER_YML_STORAGE/docker-sync.$MODE.yml" ]; then
-        echo -e "${Yellow}Using $DOCKER_YML_STORAGE/docker-sync.$MODE.yml as the docker-sync recipe.${Color_Off}"
         cp $DOCKER_YML_STORAGE/docker-sync.$MODE.yml ./$DOCKERSYNC_FILE
     else
         echo -e "${Red} Docker-sync template file missing: $DOCKER_YML_STORAGE/docker-sync.$MODE.yml.${Color_Off}"
@@ -105,9 +103,20 @@ function import_root_env() {
 # Copy .env.example to .env, display user the contents of it (to review).
 
 function create_root_env() {
-  echo -e "${Yellow}Copying .env.example -file => ${BYellow}.env${Yellow}. ${Color_Off}"
-  cat ./.env.example >> ./.env
-  import_root_env
+  if [ ! -f "./.env.example" ]; then
+    echo -e "${Red}ERROR: File ${BRed}.env.exmaple${Red} not present!.${Color_Off}";
+    return 5;
+  fi
+
+  if [ ! -f "./.env" ]; then
+    echo -e "${Green}Creating default ${BGreen}.env${Green}- file from template. ${Color_Off}"
+    cp -f ./.env.example ./.env
+  else
+    echo -e "${Yellow}Adding default values from .env.example -file to your ${BYellow}EXISTING${Yellow} ${BYellow}.env${Yellow} -file. ${Color_Off}"
+    cat ./.env.example >> ./.env
+  fi
+  echo -e "${Yellow}Your .env -file should not be committed to Git repository (and it is .gitignore'd by default).${Color_Off}"
+
   return $?
 }
 

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -106,21 +106,9 @@ function import_root_env() {
 
 function create_root_env() {
   echo -e "${Yellow}Copying .env.example -file => ${BYellow}.env${Yellow}. ${Color_Off}"
-  sleep 2
-  cp -f ./.env.example ./.env
-  echo  -e "${Yellow}Please review your ${BYellow}.env${Yellow} file: ${Color_Off}"
-  echo
-  echo -e "${BIWhite}========  START OF .env =========${Color_Off}"
-  sleep 1
-  cat ./.env
-  echo -e "${BIWhite}========  END OF .env =========${Color_Off}"
-  echo
-  read -p "Does this look okay? [Y/n] " CHOICE
-  case "$CHOICE" in
-    ''|y|Y|'yes'|'YES' ) import_root_env && echo -e "${Green}Cool, let's continue!${Color_Off}" & echo ;;
-    n|N|'no'|'NO' ) echo -e "Ok, we'll stop here. ${BYellow}Please edit .env file manually, and then start over.${Color_Off}" && return 1 ;;
-    * ) echo -e "${BRed}ERROR: Unclear answer, exiting.${Color_Off}" && cd $CWD && return 2;;
-  esac
+  cat ./.env.example >> ./.env
+  import_root_env
+  return $?
 }
 
 function function_exists() {

--- a/ld.sh
+++ b/ld.sh
@@ -55,6 +55,11 @@ if [[ "$ACTION" != 'help' ]]; then
     import_root_env
     if [[ "$?" -ne "0" ]]; then
       create_root_env
+      import_root_env
+      if [ "$?" -ne "0" ]; then
+        echo -e "${Red}ERROR: File ./.env could not be read nor created. Exiting.${Color_Off}."
+        exit 1
+      fi
     fi
 fi
 


### PR DESCRIPTION
* Read return value and exit if .env file operation failed
* Ask volume name before jumping into slower step
* Pass return value to indicate sucess of var replacing
* Change separator to not break replacing URLs with schmema
* Clean up init output, remove unnecessary questions
* Make .env file copy less verbose, remove checks
