### PR TITLE
Issue 81 better release handling for self update

### DIFF
--- a/docker/scripts/ld.command.self-update.sh
+++ b/docker/scripts/ld.command.self-update.sh
@@ -7,6 +7,7 @@ function ld_command_self-update_exec() {
     TAG=${1}
     # CHeck the tag exists if one is provided.
     if [ ! -z "$TAG" ]; then
+      echo "checking tag: $TAG"
       # GET /repos/:owner/:repo/releases/tags/:tag
       EXISTS=$(curl -sI https://api.github.com/repos/Exove/local-docker/releases/tags/${TAG} | head -1 |grep '200 OK' |wc -l)
       if [ "$EXISTS" -eq "0" ]; then
@@ -19,7 +20,7 @@ function ld_command_self-update_exec() {
     mkdir $DIR
     if [ -z "$TAG" ]; then
       # GET /repos/:owner/:repo/releases/latest
-      curl -so $DIR/${TAG}.tar.gz https://codeload.github.com/Exove/local-docker/releases/latest
+      curl -so $DIR/latest.tar.gz https://codeload.github.com/Exove/local-docker/releases/latest
     else
       # GET /repos/:owner/:repo/releases/:release_id
       curl -so $DIR/${TAG}.tar.gz https://codeload.github.com/Exove/local-docker/tar.gz/${TAG}

--- a/docker/scripts/ld.command.self-update.sh
+++ b/docker/scripts/ld.command.self-update.sh
@@ -4,25 +4,30 @@
 # This file contains self-update -command for local-docker script ld.sh.
 
 function ld_command_self-update_exec() {
-    TAG=${1}
-
-    if [ -z "$TAG" ]; then
-      echo -e "${Red}ERROR: You must provide a release tag to update to.${Color_Off}"
-      return 1
+    TAG=${1:-latest}
+    # 'latest' is not a tag
+    if [ "$TAG" != "latest" ]; then
+      # GET /repos/:owner/:repo/releases/tags/:tag
+      EXISTS=$(curl -I https://api.github.com/repos/Exove/local-docker/releases/tags/${TAG} | head -1 |grep '200 OK' |wc -l)
+      if [ "$EXISTS" -eq "0" ]; then
+        echo -e "${Red}ERROR: Specifidd tag not found.${Color_Off}"
+        return 1;
+      fi
     fi
 
-    mkdir -v ld-tmp
-    curl -o ld-tmp/${TAG}.tar.gz https://codeload.github.com/Exove/local-docker/tar.gz/${TAG}
+    DIR=".ld-tmp-" . $(date +%s)
+    mkdir -v $DIR
+    curl -o $DIR/${TAG}.tar.gz https://codeload.github.com/Exove/local-docker/tar.gz/${TAG}
     # Curl creates an ASCII file out of 404 response. Let's see what we have in the file.
-    INFO=$(file -b ld-tmp/${TAG}.tar.gz | cut -d' ' -f1)
+    INFO=$(file -b $DIR/${TAG}.tar.gz | cut -d' ' -f1)
 
     if [ "$INFO" != "gzip" ]; then
       echo -e "${Red}ERROR: Specifidd tag not found.${Color_Off}"
-      rm -rf ld-tmp
+      rm -rf $DIR
       return 1
     fi
 
-    cd ld-tmp
+    cd $DIR
     tar xvzf ${TAG}.tar.gz
     cp -r local-docker-${TAG}/docker ../
     cp -r local-docker-${TAG}/ld.sh ../
@@ -30,11 +35,11 @@ function ld_command_self-update_exec() {
     cp -r local-docker-${TAG}/.gitignore.example ../
     cd ..
     rm -rf ld-tmp
-    echo -e "${Green}Project updated to version {BGreen}${TAG}${Green}.${Color_Off}"
+    echo -e "${Green}Project updated to version ${BGreen}${TAG}${Green}.${Color_Off}"
     echo -e "${Yellow}Review and commit changes to ./docker, ld.sh, .env.example and .gitignore.example.${Color_Off}"
     echo -e "${Yellow}Review updates in .env.example and optionally update your own .env file, too.${Color_Off}"
 }
 
 function ld_command_self-update_help() {
-    echo "Updates local-docker to a specified version."
+    echo "Updates local-docker to a specified version. Omitting version updates to the latest published full release for local-docker."
 }

--- a/docker/scripts/ld.command.self-update.sh
+++ b/docker/scripts/ld.command.self-update.sh
@@ -20,10 +20,10 @@ function ld_command_self-update_exec() {
     mkdir $DIR
     if [ -z "$TAG" ]; then
       # GET /repos/:owner/:repo/releases/latest
-      curl -so $DIR/latest.tar.gz https://codeload.github.com/Exove/local-docker/releases/latest
+      curl -so $DIR/latest.tar.gz https://api.github.com/repos/Exove/local-docker/releases/latest
     else
       # GET /repos/:owner/:repo/releases/:release_id
-      curl -so $DIR/${TAG}.tar.gz https://codeload.github.com/Exove/local-docker/tar.gz/${TAG}
+      curl -so $DIR/${TAG}.tar.gz https://api.github.com/repos/Exove/local-docker/tar.gz/${TAG}
     fi
 
     # Curl creates an ASCII file out of 404 response. Let's see what we have in the file.

--- a/docker/scripts/ld.command.self-update.sh
+++ b/docker/scripts/ld.command.self-update.sh
@@ -8,7 +8,7 @@ function ld_command_self-update_exec() {
     # 'latest' is not a tag
     if [ "$TAG" != "latest" ]; then
       # GET /repos/:owner/:repo/releases/tags/:tag
-      EXISTS=$(curl -I https://api.github.com/repos/Exove/local-docker/releases/tags/${TAG} | head -1 |grep '200 OK' |wc -l)
+      EXISTS=$(curl -sI https://api.github.com/repos/Exove/local-docker/releases/tags/${TAG} | head -1 |grep '200 OK' |wc -l)
       if [ "$EXISTS" -eq "0" ]; then
         echo -e "${Red}ERROR: Specifidd tag not found.${Color_Off}"
         return 1;
@@ -17,7 +17,7 @@ function ld_command_self-update_exec() {
 
     DIR=".ld-tmp-" . $(date +%s)
     mkdir -v $DIR
-    curl -o $DIR/${TAG}.tar.gz https://codeload.github.com/Exove/local-docker/tar.gz/${TAG}
+    curl -so $DIR/${TAG}.tar.gz https://codeload.github.com/Exove/local-docker/tar.gz/${TAG}
     # Curl creates an ASCII file out of 404 response. Let's see what we have in the file.
     INFO=$(file -b $DIR/${TAG}.tar.gz | cut -d' ' -f1)
 

--- a/docker/scripts/ld.command.self-update.sh
+++ b/docker/scripts/ld.command.self-update.sh
@@ -4,9 +4,9 @@
 # This file contains self-update -command for local-docker script ld.sh.
 
 function ld_command_self-update_exec() {
-    TAG=${1:-latest}
-    # 'latest' is not a tag
-    if [ "$TAG" != "latest" ]; then
+    TAG=${1}
+    # CHeck the tag exists if one is provided.
+    if [ ! -z "$TAG" ]; then
       # GET /repos/:owner/:repo/releases/tags/:tag
       EXISTS=$(curl -sI https://api.github.com/repos/Exove/local-docker/releases/tags/${TAG} | head -1 |grep '200 OK' |wc -l)
       if [ "$EXISTS" -eq "0" ]; then
@@ -15,9 +15,16 @@ function ld_command_self-update_exec() {
       fi
     fi
 
-    DIR=".ld-tmp-" . $(date +%s)
-    mkdir -v $DIR
-    curl -so $DIR/${TAG}.tar.gz https://codeload.github.com/Exove/local-docker/tar.gz/${TAG}
+    DIR=".ld-tmp-"$(date +%s)
+    mkdir $DIR
+    if [ -z "$TAG" ]; then
+      # GET /repos/:owner/:repo/releases/latest
+      curl -so $DIR/${TAG}.tar.gz https://codeload.github.com/Exove/local-docker/releases/latest
+    else
+      # GET /repos/:owner/:repo/releases/:release_id
+      curl -so $DIR/${TAG}.tar.gz https://codeload.github.com/Exove/local-docker/tar.gz/${TAG}
+    fi
+
     # Curl creates an ASCII file out of 404 response. Let's see what we have in the file.
     INFO=$(file -b $DIR/${TAG}.tar.gz | cut -d' ' -f1)
 

--- a/docker/scripts/ld.command.self-update.sh
+++ b/docker/scripts/ld.command.self-update.sh
@@ -7,9 +7,9 @@ function ld_command_self-update_exec() {
     TAG=${1}
     # CHeck the tag exists if one is provided.
     if [ ! -z "$TAG" ]; then
-      echo "checking tag: $TAG"
+      echo "Verifying tag ${TAG} exists, read https://api.github.com/repos/Exove/local-docker/tags"
       # GET /repos/:owner/:repo/releases/tags/:tag
-      EXISTS=$(curl -sI https://api.github.com/repos/Exove/local-docker/releases/tags/${TAG} | head -1 |grep '200 OK' |wc -l)
+      EXISTS=$(curl -s https://api.github.com/repos/Exove/local-docker/tags | grep ${TAG} |wc -l)
       if [ "$EXISTS" -eq "0" ]; then
         echo -e "${Red}ERROR: Specifidd tag not found.${Color_Off}"
         return 1;
@@ -19,11 +19,18 @@ function ld_command_self-update_exec() {
     DIR=".ld-tmp-"$(date +%s)
     mkdir $DIR
     if [ -z "$TAG" ]; then
-      # GET /repos/:owner/:repo/releases/latest
-      curl -so $DIR/latest.tar.gz https://api.github.com/repos/Exove/local-docker/releases/latest
+      TAG='latest'
+      # Latest git tags is the first one in the file.
+      URL=$(curl -s https://api.github.com/repos/Exove/local-docker/tags | grep -A4 '"name"' | grep 'tarball_url' | head -1)
+      URL=$(echo $URL |cut -d'"' -f4)
+      # -L to follow redirects
+      curl -L -s -o $DIR/${TAG}.tar.gz $URL
+
     else
-      # GET /repos/:owner/:repo/releases/:release_id
-      curl -so $DIR/${TAG}.tar.gz https://api.github.com/repos/Exove/local-docker/tar.gz/${TAG}
+      URL="https://api.github.com/repos/Exove/local-docker/tarball/${TAG}"
+      # -L to follow redirects
+      curl -L -s -o $DIR/${TAG}.tar.gz $URL
+      ls -lah $DIR
     fi
 
     # Curl creates an ASCII file out of 404 response. Let's see what we have in the file.
@@ -42,12 +49,12 @@ function ld_command_self-update_exec() {
     cp -r local-docker-${TAG}/.env.example ../
     cp -r local-docker-${TAG}/.gitignore.example ../
     cd ..
-    rm -rf ld-tmp
+    rm -rf $DIR
     echo -e "${Green}Project updated to version ${BGreen}${TAG}${Green}.${Color_Off}"
     echo -e "${Yellow}Review and commit changes to ./docker, ld.sh, .env.example and .gitignore.example.${Color_Off}"
     echo -e "${Yellow}Review updates in .env.example and optionally update your own .env file, too.${Color_Off}"
 }
 
 function ld_command_self-update_help() {
-    echo "Updates local-docker to a specified version. Omitting version updates to the latest published full release for local-docker."
+    echo "Updates local-docker to a specified git tag, see https://github.com/Exove/local-docker/tags. Defaults to the latest tag for local-docker."
 }

--- a/docker/scripts/ld.command.self-update.sh
+++ b/docker/scripts/ld.command.self-update.sh
@@ -44,10 +44,11 @@ function ld_command_self-update_exec() {
 
     cd $DIR
     tar xvzf ${TAG}.tar.gz
-    cp -r local-docker-${TAG}/docker ../
-    cp -r local-docker-${TAG}/ld.sh ../
-    cp -r local-docker-${TAG}/.env.example ../
-    cp -r local-docker-${TAG}/.gitignore.example ../
+    SUBDIR=$(ls |grep local-docker)
+    cp -r $SUBDIR/docker ../
+    cp -r $SUBDIR/ld.sh ../
+    cp -r $SUBDIR/.env.example ../
+    cp -r $SUBDIR/.gitignore.example ../
     cd ..
     rm -rf $DIR
     echo -e "${Green}Project updated to version ${BGreen}${TAG}${Green}.${Color_Off}"

--- a/docker/scripts/ld.command.self-update.sh
+++ b/docker/scripts/ld.command.self-update.sh
@@ -45,15 +45,25 @@ function ld_command_self-update_exec() {
     cd $DIR
     tar xvzf ${TAG}.tar.gz
     SUBDIR=$(ls |grep local-docker)
-    cp -r $SUBDIR/docker ../
-    cp -r $SUBDIR/ld.sh ../
+    cp -r $SUBDIR/.editorconfig ../
     cp -r $SUBDIR/.env.example ../
     cp -r $SUBDIR/.gitignore.example ../
+    cp -r $SUBDIR/.github ../
+    cp -r $SUBDIR/docker ../
+    cp -r $SUBDIR/git-hooks ../
+    cp -r $SUBDIR/ld.sh ../
     cd ..
     rm -rf $DIR
     echo -e "${Green}Project updated to version ${BGreen}${TAG}${Green}.${Color_Off}"
-    echo -e "${Yellow}Review and commit changes to ./docker, ld.sh, .env.example and .gitignore.example.${Color_Off}"
-    echo -e "${Yellow}Review updates in .env.example and optionally update your own .env file, too.${Color_Off}"
+    echo -e "${Yellow}Review and commit changes to: "
+    echo " - .editorconfig"
+    echo " - .env.example"
+    echo " - .gitignore.example"
+    echo " - ./.github,"
+    echo " - ./docker,"
+    echo " - ./git-hooks and "
+    echo " - ld.sh${Color_Off}"
+    echo -e "${Yellow}Optionally update your own .env file, too.${Color_Off}"
 }
 
 function ld_command_self-update_help() {

--- a/ld.sh
+++ b/ld.sh
@@ -51,15 +51,15 @@ RESTORE_INFO="mysql --host "$${CONTAINER_DB:-db}" -uroot  -p"$MYSQL_ROOT_PASSWOR
 USERS="mysql --host "$${CONTAINER_DB:-db}" -uroot  -p"$MYSQL_ROOT_PASSWORD" -D mysql -e \"SELECT User, Host from mysql.user WHERE User NOT LIKE 'mysql%';\""
 
 # Read (and create if necessary) the .env file, allowing overrides to any of our config values.
-if [[ "$ACTION" != 'help' ]]; then
+if [[ "$ACTION" != 'help' ]] && [[ "$ACTION" != 'self-update' ]]; then
     import_root_env
     if [[ "$?" -ne "0" ]]; then
-      create_root_env
-      import_root_env
-      if [ "$?" -ne "0" ]; then
-        echo -e "${Red}ERROR: File ./.env could not be read nor created. Exiting.${Color_Off}."
-        exit 1
-      fi
+        create_root_env
+        import_root_env
+        if [ "$?" -ne "0" ]; then
+            echo -e "${Red}ERROR: File ./.env could not be read nor created. Exiting.${Color_Off}."
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
* Issue 81: Copy all files, explain what has been copied
* Issue 81: Handle dynamic tar file folder naming
* Issue 81: Use tags for updates, default to the latest tag available
* Issue 81: Use correct URL to access data
* fixup! Issue 81: Allow use of latest release and erify tag exists before use
* fixup! Issue 81: Allow use of latest release and erify tag exists before use
* Issue 81: Make curl hide progress w/ -s flag
* Issue 81: Allow use of latest release and erify tag exists before use
* Issue 81: Allow self-update on uninitialized project
