### PR TITLE
Issue 77: Set env variables to *enable* composer and nodejs containers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,13 @@ CONTAINER_DB=db
 CONTAINER_PHP=php
 CONTAINER_NGINX=nginx
 
+# Set value to 1 to use composer container (checked before the commans is run)
+CONTAINER_COMPOSER_START=0
+# Set value to 1 to use nodejs (checked before the commans is run)
+CONTAINER_NODEJS_START=0
+
+
+
 # Exposed container ports.
 CONTAINER_PORT_WEB=80
 CONTAINER_PORT_DB=3306

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -77,8 +77,7 @@ services:
     env_file:
       - .env
     working_dir: /var/www
-    #command: sh -c '[[ ! -e "/var/www/composer.lock" ]] && exit 0 || /usr/local/bin/composer install'
-    command: echo "Container 'composer' disabled."
+    command: sh -c '[[ "$CONTAINER_COMPOSER_START" -ne "1" ]] && echo "Container 'composer' disabled." && exit 0 ||  [[ ! -e "/var/www/composer.lock" ]] && echo "File /var/www/composer.lock not present, exiting." && exit 0 || /usr/local/bin/composer install'
 
   db:
     # mysql:8.0.11 keeps restarting.
@@ -150,7 +149,9 @@ services:
     working_dir: /var/www
     volumes:
       - webroot-sync-core-delegated:/var/www:nocopy
-    command: sh -c '[[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+    command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+    env_file:
+      - .env
 
 volumes:
   webroot-sync-core:

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -81,8 +81,7 @@ services:
     env_file:
       - .env
     working_dir: /var/www
-    #command: sh -c '[[ ! -e "/var/www/composer.lock" ]] && exit 0 || /usr/local/bin/composer install'
-    command: echo "Container 'composer' disabled."
+    command: sh -c '[[ "$CONTAINER_COMPOSER_START" -ne "1" ]] && echo "Container 'composer' disabled." && exit 0 ||  [[ ! -e "/var/www/composer.lock" ]] && echo "File /var/www/composer.lock not present, exiting." && exit 0 || /usr/local/bin/composer install'
 
   db:
     # mysql:8.0.11 keeps restarting.
@@ -151,7 +150,9 @@ services:
     working_dir: /var/www
     volumes:
       - webroot-sync-core-delegated:/var/www:nocopy
-    command: sh -c '[[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+    command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+    env_file:
+      - .env
 
 volumes:
   nfsmount_app:

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -83,8 +83,7 @@ services:
     env_file:
       - .env
     working_dir: /var/www
-    #command: sh -c '[[ ! -e "/var/www/composer.lock" ]] && exit 0 || /usr/local/bin/composer install'
-    command: echo "Container 'composer' disabled."
+    command: sh -c '[[ "$CONTAINER_COMPOSER_START" -ne "1" ]] && echo "Container 'composer' disabled." && exit 0 ||  [[ ! -e "/var/www/composer.lock" ]] && echo "File /var/www/composer.lock not present, exiting." && exit 0 || /usr/local/bin/composer install'
 
   db:
     # mysql:8.0.11 keeps restarting.
@@ -156,7 +155,9 @@ services:
     working_dir: /var/www
     volumes:
       - webroot-sync-core-delegated:/var/www:nocopy
-    command: sh -c '[[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+    command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+    env_file:
+      - .env
 
 volumes:
   webroot-sync-core:


### PR DESCRIPTION
Fixes issue #77 

Add env variables to both `composer` and `nodejs` containers, which are checked on bootup. If set to empty or anything other but `"1"` contaners will simply exit.