### PR TITLE
Use nfs for low urgency filesyncing

### DIFF
--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -82,7 +82,7 @@ services:
       # This share gets writes from within the container by Composer.
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
-      - webroot-sync-core-delegated:/var/www:nocopy
+      - webroot-sync-core:/var/www:nocopy
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -101,7 +101,7 @@ services:
       # This folder contains database dumps (mostly written by container).
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
-      - webroot-sync-db-dumps:/var/db_dumps:nocopy
+      - webroot-nfs-dbdumps:/var/db_dumps
       # Named volume for db table data. Docker keeps this volume around
       # unless stack is down'ed with "--volumes":
       # $ docker-compose down --volumes
@@ -150,7 +150,6 @@ services:
   mailhog:
     image: mailhog/mailhog:v1.0.0
     container_name: "${PROJECT_NAME}_mailhog"
-    restart: always
     labels:
       - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
     restart: always
@@ -164,7 +163,7 @@ services:
     container_name: "${PROJECT_NAME}_nodejs"
     working_dir: /var/www
     volumes:
-      - webroot-sync-core-delegated:/var/www:nocopy
+      - webroot-sync-core:/var/www:nocopy
     command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
     # In case of several env files later declared variable
     # values override earlier ones
@@ -175,9 +174,11 @@ services:
 volumes:
   webroot-sync-core:
     external: true
-  webroot-sync-core-delegated:
-    external: true
-  webroot-sync-db-dumps:
-    external: true
+  webroot-nfs-dbdumps:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,nfsvers=3
+      device: ":${PWD}/${DATABASE_DUMP_STORAGE:-db_dumps}"
   db_data: {}
   solr_data: {}

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -55,11 +55,11 @@ services:
         # :nocopy must be used with docker-sync
         # See bottom of this file, and ./docker-sync.yml
         - webroot-nfs-app:/var/www
-    # In case of several env files later declared variable
-    # values override earlier ones
-    env_file:
-      - .env
-      - .env.local
+      # In case of several env files later declared variable
+      # values override earlier ones
+      env_file:
+        - .env
+        - .env.local
       depends_on: # This key affects the order of which containers get started.
         - php
       working_dir: /var/www/web

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -156,7 +156,6 @@ services:
     restart: always
     labels:
       - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
-    restart: always
 
   # Replace MYTHEME with your theme name. If you have multiple the
   # clone the noodejs -section and rename the containers to something like

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -86,7 +86,7 @@ services:
       # This share gets writes from within the container by Composer.
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
-      - webroot-sync-core-delegated:/var/www:nocopy
+      - webroot-sync-core:/var/www:nocopy
       # Composer may need patches from this folder, too.
       - webroot-sync-src-patches:/var/www/web/modules/local_patches:nocopy
     # In case of several env files later declared variable
@@ -170,7 +170,7 @@ services:
     container_name: "${PROJECT_NAME}_nodejs"
     working_dir: /var/www
     volumes:
-      - webroot-sync-core-delegated:/var/www:nocopy
+      - webroot-sync-core:/var/www:nocopy
     command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
     # In case of several env files later declared variable
     # values override earlier ones
@@ -181,8 +181,6 @@ services:
 volumes:
   webroot-sync-core:
     external: true
-  webroot-sync-core-delegated:
-    external: true
   webroot-sync-src-config:
     external: true
   webroot-sync-src-modules:
@@ -191,7 +189,11 @@ volumes:
     external: true
   webroot-sync-src-themes:
     external: true
-  webroot-sync-db-dumps:
-    external: true
+  webroot-nfs-dbdumps:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,nfsvers=3
+      device: ":${PWD}/${DATABASE_DUMP_STORAGE:-db_dumps}"
   db_data: {}
   solr_data: {}

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -107,7 +107,7 @@ services:
       # This folder contains database dumps (mostly written by container).
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
-      - webroot-nfs-dbdumps:/var/db_dumps:nocopy
+      - webroot-nfs-dbdumps:/var/db_dumps
       # Named volume for db table data. Docker keeps this volume around
       # unless stack is down'ed with "--volumes":
       # $ docker-compose down --volumes

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -107,7 +107,7 @@ services:
       # This folder contains database dumps (mostly written by container).
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
-      - webroot-sync-db-dumps:/var/db_dumps:nocopy
+      - webroot-nfs-dbdumps:/var/db_dumps:nocopy
       # Named volume for db table data. Docker keeps this volume around
       # unless stack is down'ed with "--volumes":
       # $ docker-compose down --volumes
@@ -159,7 +159,6 @@ services:
     restart: always
     labels:
       - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
-    restart: always
 
   # Replace MYTHEME with your theme name. If you have multiple the
   # clone the noodejs -section and rename the containers to something like

--- a/docker/docker-sync.common.yml
+++ b/docker/docker-sync.common.yml
@@ -32,23 +32,3 @@ syncs:
     # good thing in case you are developing and want to know exactly when your changes took effect.
     # be aware in case of unison this only gives you a notification on the initial sync, not the syncs after changes.
     notify_terminal: true
-
-  webroot-sync-core-delegated:
-    sync_strategy: 'native_osx'
-    src: './${APP_ROOT}/'
-    host_disk_mount_mode: 'delegated' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
-    sync_args:
-      - "-ignore='Path .editorconfig'"  # no need to send PHPStorm config to container
-      - "-ignore='BelowPath .git'"      # also ignore .git repos in subfolders such as in composer vendor dirs
-      - "-ignore='BelowPath node_modules'" # remove this if you need code completion
-      - "-ignore='Path node_modules/*'" # remove this if you need code completion
-      # - "-ignore='Path vendor/*'"     # we could ignore the composer vendor folder, but then you won't have code completion in your IDE
-
-
-    notify_terminal: true
-
-  webroot-sync-db-dumps:
-    sync_strategy: 'native_osx'
-    src: './${DATABASE_DUMP_STORAGE:-db_dumps}/'
-    host_disk_mount_mode: 'delegated' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
-    notify_terminal: true

--- a/docker/docker-sync.skeleton.yml
+++ b/docker/docker-sync.skeleton.yml
@@ -29,18 +29,6 @@ syncs:
     # be aware in case of unison this only gives you a notification on the initial sync, not the syncs after changes.
     notify_terminal: true
 
-  webroot-sync-core-delegated:
-    sync_strategy: 'native_osx'
-    src: './${APP_ROOT}/'
-    host_disk_mount_mode: 'delegated' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
-    sync_args:
-      - "-ignore='Path .editorconfig'"  # no need to send PHPStorm config to container
-      - "-ignore='BelowPath .git'"      # also ignore .git repos in subfolders such as in composer vendor dirs
-      - "-ignore='BelowPath node_modules'" # remove this if you need code completion
-      - "-ignore='Path node_modules/*'" # remove this if you need code completion
-      # - "-ignore='Path vendor/*'"     # we could ignore the composer vendor folder, but then you won't have code completion in your IDE
-    notify_terminal: true
-
   webroot-sync-src-config:
     sync_strategy: 'native_osx'
     src: './src/config/'
@@ -70,10 +58,4 @@ syncs:
       - "-ignore='BelowPath .git'"      # also ignore .git repos in subfolders such as in composer vendor dirs
       - "-ignore='BelowPath node_modules'" # remove this if you need code completion
       - "-ignore='Path node_modules/*'" # remove this if you need code completion
-    notify_terminal: true
-
-  webroot-sync-db-dumps:
-    sync_strategy: 'native_osx'
-    src: './${DATABASE_DUMP_STORAGE:-db_dumps}/'
-    host_disk_mount_mode: 'delegated' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
     notify_terminal: true

--- a/docker/scripts/ld.command.db-backup.sh
+++ b/docker/scripts/ld.command.db-backup.sh
@@ -24,11 +24,6 @@ function ld_command_db-backup_exec() {
           ;;
 
         2|"2")
-          if ! is_dockersync && [ -f "${DOCKER_PROJECT}/${DOCKERSYNC_FILE}" ]; then
-            [ "$LD_VERBOSE" -ge "1" ] && echo 'Starting docker-sync, please wait...'
-            docker-sync start
-            DOCKER_SYNC_STARTED=1
-          fi
           COMM="docker-compose -f $DOCKER_COMPOSE_FILE  up -d $CONTAINER_DB"
           [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Yellow}Starting DB container for backup purposes.${Color_Off}"
           $COMM
@@ -54,10 +49,7 @@ function ld_command_db-backup_exec() {
         [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
        $COMM
     fi
-    if [ ! -z "$DOCKER_SYNC_STARTED" ]; then
-        [ "$LD_VERBOSE" -ge "1" ] && echo 'Turning off docker-sync (stop), please wait...'
-        docker-sync stop
-    fi
+
     echo "DB backup of database ${DBNAME} in ${DATABASE_DUMP_STORAGE:-db_dumps}/${FILENAME}"
     echo "DB backup of ${DBNAME} symlinked from: ${DATABASE_DUMP_STORAGE:-db_dumps}/db-backup--${DBNAME}--LATEST.sql.gz"
 

--- a/docker/scripts/ld.command.db-dump.sh
+++ b/docker/scripts/ld.command.db-dump.sh
@@ -19,11 +19,6 @@ function ld_command_db-dump_exec() {
           ;;
 
         2|"2")
-          if ! is_dockersync && [ -f "${DOCKER_PROJECT}/${DOCKERSYNC_FILE}" ]; then
-            [ "$LD_VERBOSE" -ge "1" ] && echo 'Starting docker-sync, please wait...'
-            docker-sync start
-            DOCKER_SYNC_STARTED=1
-          fi
           COMM="docker-compose -f $DOCKER_COMPOSE_FILE  up -d $CONTAINER_DB"
           [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Yellow}Starting DB container for backup purposes.${Color_Off}"
           $COMM

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -167,10 +167,22 @@ function ld_command_init_exec() {
         echo " [no] - Skip this, I'll build my codebase via other means"
         read -p "select version [default: 1]? " VERSION
         case "$VERSION" in
-          ''|'1'|1) COMPOSER_INIT='composer -vv create-project drupal/recommended-project:^8.8@dev /var/www --no-interaction --stability=dev';;
-          '2'|2) COMPOSER_INIT='composer -vv create-project drupal/legacy-project:^8.8@dev /var/www --no-interaction --stability=dev';;
-          '3'|3) COMPOSER_INIT='composer -vv create-project drupal-composer/drupal-project:8.x-dev /var/www --no-interaction --stability=dev';;
-          *) PROJECT='';;
+          ''|'1'|1)
+            COMPOSER_INIT='composer -vv create-project drupal/recommended-project:^8.8@dev /var/www --no-interaction --stability=dev'
+            echo -e "${Green}Creating project using ${BGreen}Drupal 8.8${Green}, recommended structure (drupal/recommended-project:^8.8@dev).${Color_Off}"
+            ;;
+          '2'|2)
+            COMPOSER_INIT='composer -vv create-project drupal/legacy-project:^8.8@dev /var/www --no-interaction --stability=dev'
+            echo -e "${Green}Creating project using ${BGreen}Drupal 8.8${Green}, legacy structure (drupal/legacy-project:^8.8@dev).${Color_Off}"
+            ;;
+          '3'|3)
+            COMPOSER_INIT='composer -vv create-project drupal-composer/drupal-project:8.x-dev /var/www --no-interaction --stability=dev'
+            echo -e "${Green}Creating project using ${BGreen}Drupal 8.7${Green}, contrib template (drupal-composer/drupal-project:8.x-dev).${Color_Off}"
+            ;;
+          *)
+            PROJECT=''
+            echo -e "${Yellow}Build phase skipped, no codebase built.${Color_Off}"
+            ;;
         esac
 
         if [ ! -z "$COMPOSER_INIT" ]; then

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -167,7 +167,7 @@ function ld_command_init_exec() {
         echo " [no] - Skip this, I'll build my codebase via other means"
         read -p "select version [default: 1]? " VERSION
         case "$VERSION" in
-          '1'|1) COMPOSER_INIT='composer -vv create-project drupal/recommended-project:^8.8@dev /var/www --no-interaction --stability=dev';;
+          ''|'1'|1) COMPOSER_INIT='composer -vv create-project drupal/recommended-project:^8.8@dev /var/www --no-interaction --stability=dev';;
           '2'|2) COMPOSER_INIT='composer -vv create-project drupal/legacy-project:^8.8@dev /var/www --no-interaction --stability=dev';;
           '3'|3) COMPOSER_INIT='composer -vv create-project drupal-composer/drupal-project:8.x-dev /var/www --no-interaction --stability=dev';;
           *) PROJECT='';;

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -153,7 +153,7 @@ function ld_command_init_exec() {
         esac
     fi
 
-
+    COMPOSER_INIT=''
     if [ "$(ls -A $APP_ROOT | wc -l | tr -d ' ')" -eq "0" ]; then
 
         echo
@@ -181,7 +181,7 @@ function ld_command_init_exec() {
             ;;
           *)
             PROJECT=''
-            echo -e "${Yellow}Build phase skipped, no codebase built.${Color_Off}"
+            echo -e "${BYellow}Build phase skipped, no codebase built!${Color_Off}"
             ;;
         esac
 
@@ -197,32 +197,32 @@ function ld_command_init_exec() {
               cd $CWD
               return 1
           fi
+          # This must be run after composer install.
+          $SCRIPT_NAME drupal-structure-fix
+          $SCRIPT_NAME drupal-files-folder-perms
           echo
           echo -e "${Green}Project created to ./$APP_ROOT folder (/var/www in containers).${Color_Off}"
         else
-          echo -e "${Yellow}No codebase built, please take care!${Color_Off}"
           echo -e "${Green}Projec root is set to ./$APP_ROOT folder (/var/www in containers).${Color_Off}"
         fi
 
-        # This must be run after composer install.
-        $SCRIPT_NAME drupal-structure-fix
-        $SCRIPT_NAME drupal-files-folder-perms
         echo
     else
       echo -en "${Red}Application root ./$APP_ROOT is not empty.${Color_Off}"
-      echo -e "${Green}No codebase built, please take care!${Color_Off}"
     fi
-
+    echo
     echo 'Bringing the containers up now... Please wait.'
     $SCRIPT_NAME up
     echo
-    echo -e "${Green}Codebase ready!!${Color_Off}"
+    echo -e "${BGreen}Codebase ready!!${Color_Off}"
     echo
-    echo -e "${Yellow}NOTE: Once Drupal is installed, you should remove write perms in sites/default -folder:${Color_Off}"
-    echo "docker-compose -f $DOCKER_COMPOSE_FILE exec php bash -c 'chmod -v 0755 web/sites/default'"
-    echo "docker-compose -f $DOCKER_COMPOSE_FILE exec php bash -c 'chmod -v 0644 web/sites/default/settings.php'"
-    echo "With these changes you can edit settings.php from host, but Drupal is happy not to be allowed to write there."
-    echo
+    if [ -z "$COMPOSER_INIT" ]; then
+      echo -e "${Yellow}NOTE: Once Drupal is installed, you should remove write perms in sites/default -folder:${Color_Off}"
+      echo "docker-compose -f $DOCKER_COMPOSE_FILE exec php bash -c 'chmod -v 0755 web/sites/default'"
+      echo "docker-compose -f $DOCKER_COMPOSE_FILE exec php bash -c 'chmod -v 0644 web/sites/default/settings.php'"
+      echo "With these changes you can edit settings.php from host, but keep Drupal happy and allow it to write these files."
+      echo
+    fi
     echo -e "${BGreen}Happy coding!${Color_Off}"
 }
 

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -7,6 +7,7 @@ function ld_command_init_exec() {
 
     VALID=0
     while [ "$VALID" -eq "0" ]; do
+        echo
         echo  -e "${BBlack}== Project name == ${Color_Off}"
         echo  "Provide a string without spaces and use chars a-z and 0-9, - and _ (no dots)."
         PROJECT_NAME=${PROJECT_NAME:-$(basename $PROJECT_ROOT)}
@@ -27,9 +28,11 @@ function ld_command_init_exec() {
     PROJECT_NAME=$(echo "$PROJECT_NAME" | sed 's/[[:space:]]/-/g')
 
     define_configuration_value PROJECT_NAME $PROJECT_NAME
+    echo -e "${BYellow}Project name is: $PROJECT_NAME.${Color_Off}"
 
     VALID=0
     while [ "$VALID" -eq "0" ]; do
+      echo
       echo  -e "${BBlack}== Local development base domain == ${Color_Off}"
       echo -e "Do not add protocol nor www -part but just the domain name. It is recommended to use domain ending with ${BBlack}.ld${Black}.${Color_Off}"
       DEFAULT=${PROJECT_NAME}.ld
@@ -50,11 +53,12 @@ function ld_command_init_exec() {
     done
     # Remove spaces.
     LOCAL_DOMAIN=$(echo "$LOCAL_DOMAIN" | sed 's/[[:space:]]/./g')
-    echo "LOCAL_DOMAIN is '$LOCAL_DOMAIN' (${#LOCAL_DOMAIN})"
     define_configuration_value LOCAL_DOMAIN $LOCAL_DOMAIN
-    echo "Default URL for drush operations is http://www.$LOCAL_DOMAIN"
+    echo -e "${BYellow}Local develoment domain is: $LOCAL_DOMAIN.${Color_Off}"
     define_configuration_value DRUSH_OPTIONS_URI "http://www."$LOCAL_DOMAIN
+    echo -e "${BYellow}Default URL for drush is: $DRUSH_OPTIONS_URI.${Color_Off}"
 
+    echo
     echo -e "${BBlack}== Local development IP address ==${Color_Off}"
     echo "Random 127.0.0.0./16 will be generated for you if you so wish?"
     read -p "Use the random IP address 127.0.0.0./16 [Y/n]? " LOCAL_IP
@@ -62,8 +66,8 @@ function ld_command_init_exec() {
         'n'|'N'|'no'|'NO') LOCAL_IP='127.0.0.1';;
         *) LAST=$((RANDOM % 240 + 3 )) && LOCAL_IP=$( printf "127.0.%d.%d\n" "$((RANDOM % 256))" "$LAST");;
     esac
-    echo -e "${Yellow}Using IP address $LOCAL_IP.${Color_Off}"
     define_configuration_value LOCAL_IP $LOCAL_IP
+    echo -e "${BYellow}IP address is: $LOCAL_IP.${Color_Off}"
 
     # 2nd param, project type.
     TYPE=${1-'common'}
@@ -74,11 +78,12 @@ function ld_command_init_exec() {
         echo -e "This does not delete your application root directory, but ${BYellow}database volumes will be destroyed.${Color_Off}"
         read -p "Continue? [y/N]" CHOICE
         case "$CHOICE" in
-            n|N|'no'|'NO' ) echo "Cancelled." && exit;;
+            n|N|'no'|'NO' ) echo "Cancelled." && return 1;;
         esac
     fi
 
-    echo "Setting up docker-compose and docker-sync files for project type '$TYPE'."
+    echo
+    [ "$LD_VERBOSE" -ge "2" ] && echo "Setting up docker-compose and docker-sync files for project type '$TYPE'."
 
     # Skeleton uses different folder as the main location for app code.
     [[ "$TYPE" == "skeleton" ]] &&  APP_ROOT='drupal'
@@ -89,6 +94,8 @@ function ld_command_init_exec() {
       echo -e "${Red}Trying to use yml files without project type.${Color_Off}"
       return 1
     fi
+
+    echo
 
     APP_ROOT=${APP_ROOT:-app}
     define_configuration_value APP_ROOT $APP_ROOT

--- a/docker/scripts/ld.command.rename-volumes.sh
+++ b/docker/scripts/ld.command.rename-volumes.sh
@@ -38,7 +38,7 @@ function ld_command_rename-volumes_exec() {
     echo "Renaming volumes to '$VOL_BASE_NAME' for docker-sync, please wait..."
     replace_in_file "s/webroot-sync/${VOL_BASE_NAME}-sync/g" $DOCKERSYNC_FILE
     replace_in_file "s/webroot-sync/${VOL_BASE_NAME}-sync/g" $DOCKER_COMPOSE_FILE
-    replace_in_file "s/webroot-nfs/${VOL_BASE_NAME}-sync/g" $DOCKER_COMPOSE_FILE
+    replace_in_file "s/webroot-nfs/${VOL_BASE_NAME}-nfs/g" $DOCKER_COMPOSE_FILE
 }
 
 #function ld_command_rename-volumes_help() {

--- a/docker/scripts/ld.command.rename-volumes.sh
+++ b/docker/scripts/ld.command.rename-volumes.sh
@@ -7,6 +7,7 @@ function ld_command_rename-volumes_exec() {
     VOL_BASE_NAME=$1
     VALID=0
     while [ "$VALID" -eq "0" ]; do
+        echo
         echo -e "${BBlack}==  Container volume base name ==${Color_Off}"
         if [[ -z "$VOL_BASE_NAME" ]] || [ ! -z "$VOL_BASE_NAME_DEFAULT_FAILED" ]; then
             read -p "Container volume base name ['$VOL_BASE_NAME']: " ANSWER

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -149,7 +149,7 @@ function create_project_config_file() {
     echo -e "${Red}ERROR: File ${BRed}${TEMPLATE}${Red} does not exist!.${Color_Off}";
     return 5;
   fi
-  ls -lha $FILE
+
   if [ ! -f "$FILE" ]; then
     echo -e "${Green}Creating default ${BGreen}${FILE}${Green} file from the template. ${Color_Off}"
     cp -f ${TEMPLATE} ${FILE}

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -53,9 +53,9 @@ function db_connect() {
     ROUNDS_MAX=30
     if [ -z "$CONTAINER_DB_ID" ]; then
       return 2
-    else
-      echo -n  "Connecting to DB container ($CONTAINER_DB_ID), please wait .."
     fi
+
+    echo -n  "Connecting to DB container ($CONTAINER_DB_ID), please wait .."
 
     while [ -z "$RESPONSE" ] || [ "$RESPONSE" -eq "0" ]; do
         ROUND=$(( $ROUND + 1 ))


### PR DESCRIPTION
Remove all :delegated -volumes, and use the regular volume (:cached) with docker-sync. 

Move all db_dump -containers to use nfs-share, and start+stop of docker-sync when running database backups (now when the db volume does not use docker-sync anymore)