### PR TITLE
Issue 116 fix env var expansion for php vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,5 +99,4 @@ PHP_XDEBUG_REMOTE_HOST=host.docker.internal
 # running on the host.
 PHP_XDEBUG_REMOTE_PORT=9010
 # Logging is off by default as the log file may grow quite a bit in short time.
-PHP_XDEBUG_REMOTE_LOG=/var/www/xdebug.log
-
+#PHP_XDEBUG_REMOTE_LOG=/var/www/xdebug.log

--- a/.env.example
+++ b/.env.example
@@ -68,10 +68,14 @@ MYSQL_PASSWORD=drupal
 ############################
 ##### PHP configuration ####
 
+# NOTE: Variables PHP_*  are used in PHP's INI files:
+# docker/build/php/*/conf.d/95-drupal-development.ini
+
 # Do not use name PHP_VERSION for the variable, it collides with PHP internals.
 # Valid options are 7.1, 7.2 (see build file paths in docker/build/php).
 # Changes to this value will take effect only after buiding PHP container:
 # $ docker-compose up -d --build php
+# Valid values: 7.1, 7.2
 PROJECT_PHP_VERSION=7.2
 
 # Let the composer run as root without constant complaining.
@@ -95,5 +99,5 @@ PHP_XDEBUG_REMOTE_HOST=host.docker.internal
 # running on the host.
 PHP_XDEBUG_REMOTE_PORT=9010
 # Logging is off by default as the log file may grow quite a bit in short time.
-#PHP_XDEBUG_REMOTE_LOG=/var/log/xdebug.log
+PHP_XDEBUG_REMOTE_LOG=/var/www/xdebug.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 .idea
 .docker-sync
 .env.local
+app/xdebug.log

--- a/db_dumps/.gitignore
+++ b/db_dumps/.gitignore
@@ -1,2 +1,5 @@
-db-container*.sql*
+# Full DB coantainer dumps.
+db-container--*.sql*
+# Single database dumps.
+db-backup--*.sql*
 

--- a/docker/build/php/7.1/conf.d/95-drupal-development.ini
+++ b/docker/build/php/7.1/conf.d/95-drupal-development.ini
@@ -1,3 +1,7 @@
+; Base config is already in, but here are some overrides.
+; Any changes here will be applied only after rebuilding `php` container.
+; In local-docker some values are set via environment variables.
+
 allow_url_fopen = 1
 display_errors = 1
 memory_limit = ${PHP_MEMORY_LIMIT}
@@ -13,19 +17,7 @@ opcache.validate_timestamps=1
 ; XDEBUG conf
 ; ============
 ;
-; Base config is already in, but here are some overrides.
-; Any changes here will be applied only after rebuilding `php` container.
-
-; Set remote_enable to 0 to disable xdebug.
-;xdebug.remote_enable=0
-
-; Common value is 9000, but we avoid collisions with host -side php-fpm by
-; using some other value.
-xdebug.remote_port = ${PHP_XDEBUG_REMOTE_PORT:-9000}
-xdebug.remote_host= ${PHP_XDEBUG_REMOTE_HOST}
-xdebug.remote_enable= ${PHP_XDEBUG_REMOTE_ENABLE:-1}
-
-; Enable to gather xdebug log inside `php` container.
-; When things are rolling good this provides no additional value
-; but just eat resources.
-xdebug.remote_log=${PHP_XDEBUG_REMOTE_LOG}
+xdebug.remote_enable = ${PHP_XDEBUG_REMOTE_ENABLE}
+xdebug.remote_host=  ${PHP_XDEBUG_REMOTE_HOST}
+xdebug.remote_port = ${PHP_XDEBUG_REMOTE_PORT}
+xdebug.remote_log = ${PHP_XDEBUG_REMOTE_LOG}

--- a/docker/build/php/7.1/conf.d/95-drupal-development.ini
+++ b/docker/build/php/7.1/conf.d/95-drupal-development.ini
@@ -10,6 +10,7 @@ post_max_size = 500M
 upload_max_filesize = 500M
 max_execution_time = 600
 max_children = 8
+error_reporting = E_ALL
 
 opcache.validate_timestamps=1
 

--- a/docker/build/php/7.2/conf.d/95-drupal-development.ini
+++ b/docker/build/php/7.2/conf.d/95-drupal-development.ini
@@ -1,3 +1,7 @@
+; Base config is already in, but here are some overrides.
+; Any changes here will be applied only after rebuilding `php` container.
+; In local-docker some values are set via environment variables.
+
 allow_url_fopen = 1
 display_errors = 1
 memory_limit = ${PHP_MEMORY_LIMIT}
@@ -13,19 +17,7 @@ opcache.validate_timestamps=1
 ; XDEBUG conf
 ; ============
 ;
-; Base config is already in, but here are some overrides.
-; Any changes here will be applied only after rebuilding `php` container.
-
-; Set remote_enable to 0 to disable xdebug.
-;xdebug.remote_enable=0
-
-; Common value is 9000, but we avoid collisions with host -side php-fpm by
-; using some other value.
-xdebug.remote_port = ${PHP_XDEBUG_REMOTE_PORT:-9000}
-xdebug.remote_host= ${PHP_XDEBUG_REMOTE_HOST}
-xdebug.remote_enable= ${PHP_XDEBUG_REMOTE_ENABLE:-1}
-
-; Enable to gather xdebug log inside `php` container.
-; When things are rolling good this provides no additional value
-; but just eat resources.
-xdebug.remote_log=${PHP_XDEBUG_REMOTE_LOG}
+xdebug.remote_enable = ${PHP_XDEBUG_REMOTE_ENABLE}
+xdebug.remote_host=  ${PHP_XDEBUG_REMOTE_HOST}
+xdebug.remote_port = ${PHP_XDEBUG_REMOTE_PORT}
+xdebug.remote_log = ${PHP_XDEBUG_REMOTE_LOG}

--- a/docker/build/php/7.2/conf.d/95-drupal-development.ini
+++ b/docker/build/php/7.2/conf.d/95-drupal-development.ini
@@ -10,6 +10,7 @@ post_max_size = 500M
 upload_max_filesize = 500M
 max_execution_time = 600
 max_children = 8
+error_reporting = E_ALL
 
 opcache.validate_timestamps=1
 

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -70,8 +70,6 @@ services:
     env_file:
       - .env
       - .env.local
-    environment:
-        XDEBUG_CONFIG: "remote_enable=${PHP_XDEBUG_REMOTE_ENABLE}"
     working_dir: /var/www
 
   composer:

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -77,8 +77,6 @@ services:
     env_file:
       - .env
       - .env.local
-    environment:
-        XDEBUG_CONFIG: "remote_enable=${PHP_XDEBUG_REMOTE_ENABLE}"
     working_dir: /var/www
 
   composer:

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -74,8 +74,6 @@ services:
     env_file:
       - .env
       - .env.local
-    environment:
-        XDEBUG_CONFIG: "remote_enable=${PHP_XDEBUG_REMOTE_ENABLE}"
     working_dir: /var/www
 
   composer:


### PR DESCRIPTION
Fix project's PHP .ini file notation to utilize .env -file configuration (notation with default value `${VAR:-DEFAULT}`does not work, but `${VAR}` does).

As a side effect we do not need the `services.php.environment` -values anymore, since all currently set vars are used via .ini file(s).

Includes also small fix to db_dumps folder's .gitignore -file, to ignore db dump files introduced in #96 

Fixes #116 