### PR TITLE
Issue 118 self updater release tag check fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,11 +310,22 @@ alias to your shell startup files. In order to not interfere with `/usr/bin/ld`,
 
 Then, you can use `lld` instead of `./ld` or `./ld.sh`
 
+#### Update local-docker itself
+
+Since project repository is detached from the `local-docker` repository
+there is a script to get the new updates for the local-docker itself.
+
+    $ docker/scripts/self-update.sh [RELEASE]
+
+Script defaults to using the latest release. All available releases can
+be seen in
+[https://github.com/Exove/local-docker/releases](https://github.com/Exove/local-docker/releases).
+
 ## Projects in parallel
 
-`local-docker` isolates local projects behind IP aliases (alias to the 
-loopback interface) and therefore running projects in parallel s
-possible.
+`local-docker` isolates local projects behind IP aliases (alias to the
+loopback interface) and therefore you can run several projects in
+parallel.
 
 In case there are port collisions first thing to check is you have
 `.ld.config` file with `LOCAL_IP` set to something other than `127.0.0.1`.

--- a/docker/scripts/ld.command.self-update.sh
+++ b/docker/scripts/ld.command.self-update.sh
@@ -6,9 +6,10 @@
 function ld_command_self-update_exec() {
     echo -e "${BYellow}This command is removed.${Color_Off}"
     echo -e "${Yellow}You can update the local-docker issuing command from your PROJECT_ROOT.${Color_Off}"
-    echo -e "${Yellow}docker/scripts/self-update.sh TAG.${Color_Off}"
+    echo -e "\$ ${Yellow}docker/scripts/self-update.sh RELEASE-NAME.${Color_Off}"
+    echo -e "${Yellow}View available releases: ${BYellow}https://github.com/Exove/local-docker/releases${Yellow}.${Color_Off}"
 }
 
 function ld_command_self-update_help() {
-    echo "[REMOVED] Update local-docker with '\$ docker/scripts/self-update.sh TAG'."
+    echo "Updates local-docker to a specified release, see https://github.com/Exove/local-docker/releases. Defaults to the latest release."
 }

--- a/docker/scripts/ld.command.self-update.sh
+++ b/docker/scripts/ld.command.self-update.sh
@@ -6,10 +6,10 @@
 function ld_command_self-update_exec() {
     echo -e "${BYellow}This command is removed.${Color_Off}"
     echo -e "${Yellow}You can update the local-docker issuing command from your PROJECT_ROOT.${Color_Off}"
-    echo -e "\$ ${Yellow}docker/scripts/self-update.sh RELEASE-NAME.${Color_Off}"
+    echo -e "\$ ${Yellow}docker/scripts/self-update.sh [TAG].${Color_Off}"
     echo -e "${Yellow}View available releases: ${BYellow}https://github.com/Exove/local-docker/releases${Yellow}.${Color_Off}"
 }
 
 function ld_command_self-update_help() {
-    echo "Updates local-docker to a specified release, see https://github.com/Exove/local-docker/releases. Defaults to the latest release."
+    echo "Updates local-docker to a specified release, see https://github.com/Exove/local-docker/releases. Defaults to the latest release (may or may not be the latest TAG)."
 }

--- a/docker/scripts/self-update.sh
+++ b/docker/scripts/self-update.sh
@@ -4,9 +4,9 @@
 # This file contains self-update -command for local-docker script ld.sh.
 # Get colors.
 if [ ! -f "./docker/scripts/ld.colors.sh" ]; then
-  echo "File ./docker/scripts/ld.colors.sh missing."
-  echo "You are currently in "$(pwd)
-  exit 1;
+    echo "File ./docker/scripts/ld.colors.sh missing."
+    echo "You are currently in "$(pwd)
+    exit 1;
 fi
 . ./docker/scripts/ld.colors.sh
 
@@ -51,9 +51,9 @@ fi
 # Curl creates an ASCII file out of 404 response. Let's see what we have in the file.
 INFO=$(file -b $DIR/$TEMP_FILENAME | cut -d' ' -f1)
 if [ "$INFO" != "gzip" ]; then
-  echo -e "${Red}ERROR: Specifidd tag not found.${Color_Off}"
-  rm -rf $DIR
-  return 1
+    echo -e "${Red}ERROR: Download the the requested release failed.${Color_Off}"
+    rm -rf $DIR
+    return 1
 fi
 
 tar xzf $DIR/$TEMP_FILENAME -C $DIR
@@ -64,9 +64,12 @@ for FILE in $LIST; do
 done
 
 rm -rf $DIR
-echo -e "${Green}Project updated to version ${BGreen}${TAG}${Green}.${Color_Off}"
+echo
+echo -e "${Green}Local-docker updated to version ${BGreen}${RELEASE_NAME}${Green}.${Color_Off}"
+echo
 echo -e "${Yellow}Review and commit changes to: "
 for FILE in $LIST; do
-  echo " - $FILE"
+    echo " - $FILE"
 done
+
 echo -e "${Yellow}Optionally update your own .env.local file, too.${Color_Off}"

--- a/docker/scripts/self-update.sh
+++ b/docker/scripts/self-update.sh
@@ -12,21 +12,33 @@ fi
 
 # When no tag is provided we'll fallback to use the 'latest'.
 TAG=${1:-latest}
-TAG_PROVIDED=1
-if [ -z "$1" ];then
-    TAG_PROVIDED=
+TAG_PROVIDED=
+if [ -n "$1" ];then
+    TAG_PROVIDED=1
 fi
 
 # Check the tag exists if one is provided.
-[ ! -z "$TAG_PROVIDED" ] && echo "Verifying release ${TAG} exists, please wait..."
-[ -z "$TAG_PROVIDED" ]  && echo "Getting the latest release info, please wait..."
-CURL="curl -sL https://api.github.com/repos/Exove/local-docker/releases/${TAG}"
-EXISTS="|"$($CURL | grep -e '"name":' -e '"html_url":.*local-docker' -e '"published_at":' -e '"tarball_url":' -e '"body":' | tr '\n' '|')
-if [ -z "$EXISTS" ]; then
-    echo -e "${Red}ERROR: The specified release was not found.${Color_Off}"
-    exit
+if [ -n "$TAG_PROVIDED" ]; then
+    echo "Looking for tag ${TAG}, please wait..."
+    CURL="curl -sL https://api.github.com/repos/Exove/local-docker/releases/tags/${TAG}"
+    EXISTS=$($CURL | grep -e '"name":' -e '"html_url":.*local-docker' -e '"published_at":' -e '"tarball_url":' -e '"body":' | tr '\n' '|')
+    if [ -z "$EXISTS"  ]; then
+        echo -e "${Red}ERROR: The tag release was not found.${Color_Off}"
+        exit 2
+    fi
+else
+    echo "Requesting the latest release info, please wait..."
+    # GET /repos/:owner/:repo/releases/latest
+    CURL="curl -sL https://api.github.com/repos/Exove/local-docker/releases/latest"
+    EXISTS=$($CURL | grep -e '"name":' -e '"html_url":.*local-docker' -e '"published_at":' -e '"tarball_url":' -e '"body":' | tr '\n' '|')
+    if [ -z "$EXISTS"  ]; then
+        echo -e "${Red}ERROR: No information about the latest release available.${Color_Off}"
+        exit 3
+    fi
 fi
 
+
+EXISTS="|$EXISTS"
 RELEASE_NAME=$(echo $EXISTS | grep -o -e '|\s*"name":[^|)]*' |cut -d'"' -f4)
 RELEASE_PUBLISHED=$(echo $EXISTS | grep -o -e '|\s*"published_at":[^|)]*' |cut -d'"' -f4)
 RELEASE_TARBALL=$(echo $EXISTS | grep -o -e '|\s*"tarball_url":[^|)]*' |cut -d'"' -f4)
@@ -35,35 +47,39 @@ RELEASE_BODY=$(echo $EXISTS | grep -o -e '|\s*"body":[^|)]*' |cut -d'"' -f4)
 
 DIR=".ld-tmp-"$(date +%s)
 mkdir $DIR
-TEMP_FILENAME=release-${RELEASE_NAME}.tar.gz
-if [ -z "$TAG_PROVIDED" ]; then
+# Remove whitespaces we do not wish to deal with in filenames.
+RELEASE_NAME_CLEAN=$(echo $RELEASE_NAME | sed -e 's/^[[:space:]]*//')
+TEMP_FILENAME="release-${RELEASE_NAME_CLEAN}.tar.gz"
+if [ -n "$RELEASE_TARBALL" ]; then
      # Latest git tags is the first one in the file.
     echo -e "Release name : ${BGreen} $RELEASE_NAME${Color_Off}"
     echo -e "Published    : ${BGreen} $RELEASE_PUBLISHED${Color_Off}"
     echo -e "Release page : ${BGreen} $RELEASE_PAGE${Color_Off}"
     echo -e "Release info : "
     echo -e "${BGreen}$RELEASE_BODY${Color_Off}"
+    echo
     echo "Downloading release from $RELEASE_TARBALL, please wait..."
     # -L to follow redirects
-    curl -L -s -o $DIR/$TEMP_FILENAME $RELEASE_TARBALL
+    curl -L -s -o "$DIR/$TEMP_FILENAME" $RELEASE_TARBALL
 fi
 
 # Curl creates an ASCII file out of 404 response. Let's see what we have in the file.
 INFO=$(file -b $DIR/$TEMP_FILENAME | cut -d' ' -f1)
 if [ "$INFO" != "gzip" ]; then
-    echo -e "${Red}ERROR: Download the the requested release failed.${Color_Off}"
-    rm -rf $DIR
-    return 1
+    echo -e "${Red}ERROR: Downloading the requested release failed.${Color_Off}"
+    rm -rf $(pwd)/$DIR
+    exit 4
 fi
 
-tar xzf $DIR/$TEMP_FILENAME -C $DIR
-SUBDIR=$(ls |grep local-docker)
+tar xzf "$DIR/$TEMP_FILENAME" -C "$DIR"
+SUBDIR=$(ls $DIR |grep local-docker)
 LIST=" .editorconfig .env.example .env.local.example .gitignore.example ./.github ./docker ./git-hooks ld.sh"
 for FILE in $LIST; do
-    cp -fr $DIR/$SUBDIR/$FILE . 2>/dev/null
+    cp -fr "$DIR/$SUBDIR/$FILE" .
 done
 
-rm -rf $DIR
+# Remove temp dir, but take precautions, the DIR value must not remove root (/).
+rm -rf "$(pwd)/$DIR"
 echo
 echo -e "${Green}Local-docker updated to version ${BGreen}${RELEASE_NAME}${Green}.${Color_Off}"
 echo


### PR DESCRIPTION
- Added info to README how to update the local-docker itself
- Update self-update -command info (even if not used)
- Whitespace + indenting, minor UI text updates
- use **releases**, not tags
- Use latest release or a release with a given name