### PR TITLE
Increase upload file size limit w/ nginx

### DIFF
--- a/docker/build/nginx/conf.d/default.conf
+++ b/docker/build/nginx/conf.d/default.conf
@@ -13,6 +13,8 @@ server {
     fastcgi_buffers 4 256k;
     fastcgi_buffer_size 128k;
 
+    client_max_body_size 500m;
+
     # Prevent infifite loop with D8 + Redirect -module.
     # https://www.nginx.com/resources/wiki/start/topics/recipes/drupal/
 


### PR DESCRIPTION
Increases accepted post file size to 500M in `nginx` (`php` builds do have the same value)