### PR TITLE
Fix "bad substitution" in db-import -script

### DIFF
--- a/docker/scripts/ld.command.db-import.sh
+++ b/docker/scripts/ld.command.db-import.sh
@@ -5,7 +5,7 @@
 
 # Restore one database from backup.
 function ld_command_db-import_exec() {
-    DBNAME=${1:$-${MYSQL_DATABASE:-drupal}}
+    DBNAME=${1:-${MYSQL_DATABASE:-drupal}}
     if [ -z "$DBNAME" ]; then
       echo -e "${Red}ERROR: No database name provided nor found.${Color_Off}"
       return 1


### PR DESCRIPTION
Fixes command ./ld db-import [drupal] [path-to-file] being un-executable due to broken variable substitution