### PR TITLE
134 improve stability of self update

### DIFF
--- a/docker/scripts/ld.command.self-update.sh
+++ b/docker/scripts/ld.command.self-update.sh
@@ -3,11 +3,24 @@
 #
 # This file contains self-update -command for local-docker script ld.sh.
 
+SELF_UPDATE_SCRIPT=./docker/scripts/self-update.sh
+SELF_UPDATE_TEMP_SCRIPT=./self-update.sh
+
 function ld_command_self-update_exec() {
-    echo -e "${BYellow}This command is removed.${Color_Off}"
-    echo -e "${Yellow}You can update the local-docker issuing command from your PROJECT_ROOT.${Color_Off}"
-    echo -e "\$ ${Yellow}docker/scripts/self-update.sh [TAG].${Color_Off}"
-    echo -e "${Yellow}View available releases: ${BYellow}https://github.com/Exove/local-docker/releases${Yellow}.${Color_Off}"
+    # Make a copy of the self-update script itself to avoid the update process
+    # breaking when the self-update script itself is changed.
+    cp "${SELF_UPDATE_SCRIPT}" "${SELF_UPDATE_TEMP_SCRIPT}"
+    # Use the copy to perform the actual update.
+    . "${SELF_UPDATE_TEMP_SCRIPT}" "$@"
+    # The copy should remove itself, but check anyway.
+    if [[ -e "${SELF_UPDATE_TEMP_SCRIPT}" ]] ; then
+        echo -e "${Yellow}WARNING: The self-update may have been partially unsuccessfull since a temporary copy of the self-update script failed to remove itself."
+        echo -e "You should probably try to run the command again.${Color_Off}"
+        read -r -p "Remove the temporary copy ${SELF_UPDATE_TEMP_SCRIPT}? (Y/n): "
+        if [[ ! ( $REPLY =~ ^[Nn] ) ]] ; then
+            rm "${SELF_UPDATE_TEMP_SCRIPT}"
+        fi
+    fi
 }
 
 function ld_command_self-update_help() {

--- a/docker/scripts/ld.command.self-update.sh
+++ b/docker/scripts/ld.command.self-update.sh
@@ -21,6 +21,8 @@ function ld_command_self-update_exec() {
             rm "${SELF_UPDATE_TEMP_SCRIPT}"
         fi
     fi
+    # If we return to the ld script and it has changed, things may break.
+    exit 0
 }
 
 function ld_command_self-update_help() {

--- a/docker/scripts/self-update.sh
+++ b/docker/scripts/self-update.sh
@@ -14,13 +14,9 @@ fi
 
 # When no tag is provided we'll fallback to use the 'latest'.
 TAG=${1:-latest}
-TAG_PROVIDED=
-if [ -n "$1" ];then
-    TAG_PROVIDED=1
-fi
 
-# Check the tag exists if one is provided.
-if [ -n "$TAG_PROVIDED" ]; then
+# Check the tag exists if one was provided.
+if [ $# -ne 0 ]; then
     echo "Looking for tag ${TAG}, please wait..."
     CURL="curl -sL https://api.github.com/repos/Exove/local-docker/releases/tags/${TAG}"
     EXISTS=$($CURL | grep -e '"name":' -e '"html_url":.*local-docker' -e '"published_at":' -e '"tarball_url":' -e '"body":' | tr '\n' '|')

--- a/docker/scripts/self-update.sh
+++ b/docker/scripts/self-update.sh
@@ -2,8 +2,9 @@
 # File
 #
 # This file contains self-update -command for local-docker script ld.sh.
-# Strict mode (without strict IFS): http://redsymbol.net/articles/unofficial-bash-strict-mode/
+# Strict mode http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -euo pipefail
+IFS=$'\n\t'
 # Get colors.
 if [ ! -f "./docker/scripts/ld.colors.sh" ]; then
     echo "File ./docker/scripts/ld.colors.sh missing."
@@ -82,8 +83,17 @@ fi
 
 tar xzf "$DIR/$TEMP_FILENAME" -C "$DIR"
 SUBDIR=$(ls $DIR |grep local-docker)
-LIST=" .editorconfig .env.example .env.local.example .gitignore.example ./.github ./docker ./git-hooks ld.sh"
-for FILE in $LIST; do
+UPDATE_TARGETS=(
+    ".editorconfig"
+    ".env.example"
+    ".env.local.example"
+    ".gitignore.example"
+    "./.github"
+    "./docker"
+    "./git-hooks"
+    "ld.sh"
+)
+for FILE in "${UPDATE_TARGETS[@]}" ; do
     cp -fr "$DIR/$SUBDIR/$FILE" .
 done
 

--- a/docker/scripts/self-update.sh
+++ b/docker/scripts/self-update.sh
@@ -2,6 +2,8 @@
 # File
 #
 # This file contains self-update -command for local-docker script ld.sh.
+# Strict mode (without strict IFS): http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
 # Get colors.
 if [ ! -f "./docker/scripts/ld.colors.sh" ]; then
     echo "File ./docker/scripts/ld.colors.sh missing."

--- a/docker/scripts/self-update.sh
+++ b/docker/scripts/self-update.sh
@@ -18,8 +18,8 @@ TAG=${1:-latest}
 # Check the tag exists if one was provided.
 if [ $# -ne 0 ]; then
     echo "Looking for tag ${TAG}, please wait..."
-    CURL="curl -sL https://api.github.com/repos/Exove/local-docker/releases/tags/${TAG}"
-    EXISTS=$($CURL | grep -e '"name":' -e '"html_url":.*local-docker' -e '"published_at":' -e '"tarball_url":' -e '"body":' | tr '\n' '|')
+    URL="https://api.github.com/repos/Exove/local-docker/releases/tags/${TAG}"
+    EXISTS=$(curl -sL "${URL}" | grep -e '"name":' -e '"html_url":.*local-docker' -e '"published_at":' -e '"tarball_url":' -e '"body":' | tr '\n' '|')
     if [ -z "$EXISTS"  ]; then
         echo -e "${Red}ERROR: The tag release was not found.${Color_Off}"
         exit 2
@@ -27,8 +27,8 @@ if [ $# -ne 0 ]; then
 else
     echo "Requesting the latest release info, please wait..."
     # GET /repos/:owner/:repo/releases/latest
-    CURL="curl -sL https://api.github.com/repos/Exove/local-docker/releases/latest"
-    EXISTS=$($CURL | grep -e '"name":' -e '"html_url":.*local-docker' -e '"published_at":' -e '"tarball_url":' -e '"body":' | tr '\n' '|')
+    URL="https://api.github.com/repos/Exove/local-docker/releases/latest"
+    EXISTS=$(curl -sL "${URL}" | grep -e '"name":' -e '"html_url":.*local-docker' -e '"published_at":' -e '"tarball_url":' -e '"body":' | tr '\n' '|')
     if [ -z "$EXISTS"  ]; then
         echo -e "${Red}ERROR: No information about the latest release available.${Color_Off}"
         exit 3

--- a/docker/scripts/self-update.sh
+++ b/docker/scripts/self-update.sh
@@ -87,3 +87,10 @@ for FILE in $LIST; do
 done
 
 echo -e "${Yellow}Optionally update your own .env.local file, too.${Color_Off}"
+
+if [[ "${BASH_SOURCE[0]}" == './self-update.sh' ]] ; then
+    # We are at project root, and with the script being in project root, it means
+    # that we are executing a copy made by docker/scripts/ld.command.self-update.sh
+    # so we should remove this temporary copy as the last step of execution.
+    rm "${BASH_SOURCE[0]}"
+fi

--- a/docker/scripts/self-update.sh
+++ b/docker/scripts/self-update.sh
@@ -101,7 +101,7 @@ echo
 echo -e "${Green}Local-docker updated to version ${BGreen}${RELEASE_NAME}${Green}.${Color_Off}"
 echo
 echo -e "${Yellow}Review and commit changes to: "
-for FILE in $LIST; do
+for FILE in "${UPDATE_TARGETS[@]}" ; do
     echo " - $FILE"
 done
 


### PR DESCRIPTION
This PR should fix issues mentioned in #134.

The main changes related to that are that `./ld self-update` now performs the following actions:
1. Makes a copy of the self-update script to current directory
2. It executes that copy.
3. The copy performs the self-update.
4. The copy removes itself.
5. `./ld self-update` checks if the copy is removed and if not, warns that something maybe wrong and prompts for removing the copy.

Additional changes:
* `self-update.sh` uses more strict bash options, which introduces some safety by failing on script errors.
* An array is used for files to be updated instead of exploding strings.
* A separate variable is not used for determining whether a tag argument was given.
* Curl command and its options are separated from the URL.
* If a system temporary directory is available, the temporary directory for the release is created under that.
* If the release has already been downloaded there, it won't be downloaded again.