### PR TITLE
Issue 139 fix missing composer binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ commands `php` container tries to connect to your IDE:
 This Xdebug configuration is initially set in the base image this
 project is using (`xoxoxo/php-container`). However this can be
 overridden for example in
-[95-drupal-development.ini file (PHP 7.2)](./docker/build/php7.2//conf.d/95-drupal-development.ini)
+[95-drupal-development.ini file (PHP 7.3)](./docker/build/php7.3/conf.d/95-drupal-development.ini)
 , and Xdebug's full config can be checked either from Drupal
 (`admin/reports/status/php`) or with command
 

--- a/docker/build/php/7.3/Dockerfile
+++ b/docker/build/php/7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM xoxoxo/php-drupal:7.3-1.0
+FROM xoxoxo/php-drupal:7.3-1.1
 
 # Configure PHP for local development.
 COPY ./conf.d/90-mailhog.ini /usr/local/etc/php/conf.d/90-mailhog.ini


### PR DESCRIPTION
Fixes #139 

Using newer version of php-drupal -container, which should solve the issue.