### PR TITLE
Add loadbalancer port forwarding to Mailhog labels

### DIFF
--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -155,6 +155,7 @@ services:
     container_name: "${PROJECT_NAME}_mailhog"
     labels:
       - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.services.${PROJECT_NAME}--mailhog.loadbalancer.server.port=8025"
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -160,6 +160,7 @@ services:
     container_name: "${PROJECT_NAME}_mailhog"
     labels:
       - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.services.${PROJECT_NAME}--mailhog.loadbalancer.server.port=8025"
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -162,6 +162,7 @@ services:
     container_name: "${PROJECT_NAME}_mailhog"
     labels:
       - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.services.${PROJECT_NAME}--mailhog.loadbalancer.server.port=8025"
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the


### PR DESCRIPTION
Fixes Mailhog UI not being accessible. Traefik did not do port-forwading to a correct port, thus explicitly setting the correct UI port here.