### PR TITLE
Add phpcs command

### DIFF
--- a/docker/scripts/ld.command.phpcbf.sh
+++ b/docker/scripts/ld.command.phpcbf.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# File
+#
+# This file contains phpcbf command for local-docker script ld.sh.
+
+function ld_command_phpcbf_exec() {
+    CONT_ID=$(find_container ${CONTAINER_PHP:-php})
+    if [ "$?" -eq "1" ]; then
+      echo -e "${Red}ERROR: Trying to locate a container with empty name.${Color_Off}"
+      return 1
+    fi
+    if [ -z "$CONT_ID" ]; then
+      echo -e "${Red}ERROR: PHP container ('${CONTAINER_PHP:-php}')is not up.${Color_Off}"
+      return 2
+    fi
+    COMM="docker-compose exec ${CONTAINER_PHP:-php} /var/www/vendor/bin/phpcbf $@"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
+    $COMM
+}
+
+function ld_command_phpcbf_help() {
+    echo "Run phpcbf command in PHP container (if up and running)."
+}
+
+function ld_command_phpcbf_extended_help() {
+    echo "Drupal and DrupalPractice coding standards will be supported as long as"
+    echo "dealerdirect/phpcodesniffer-composer-installer package has been installed."
+    echo "To target e.g. your custom modules, use /var/www/web/modules/custom as the argument."
+    echo
+    echo "Example: $SCRIPT_NAME_SHORT phpcbf --standard=Drupal,DrupalPractice /var/www/web/modules/custom"
+}

--- a/docker/scripts/ld.command.phpcs.sh
+++ b/docker/scripts/ld.command.phpcs.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# File
+#
+# This file contains phpcs command for local-docker script ld.sh.
+
+function ld_command_phpcs_exec() {
+    CONT_ID=$(find_container ${CONTAINER_PHP:-php})
+    if [ "$?" -eq "1" ]; then
+      echo -e "${Red}ERROR: Trying to locate a container with empty name.${Color_Off}"
+      return 1
+    fi
+    if [ -z "$CONT_ID" ]; then
+      echo -e "${Red}ERROR: PHP container ('${CONTAINER_PHP:-php}')is not up.${Color_Off}"
+      return 2
+    fi
+    COMM="docker-compose exec ${CONTAINER_PHP:-php} /var/www/vendor/bin/phpcs $@"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
+    $COMM
+}
+
+function ld_command_phpcs_help() {
+    echo "Run phpcs command in PHP container (if up and running)."
+}
+
+function ld_command_phpcs_extended_help() {
+    echo "Drupal and DrupalPractice coding standards will be supported as long as"
+    echo "dealerdirect/phpcodesniffer-composer-installer package has been installed."
+    echo "To target e.g. your custom modules, use /var/www/web/modules/custom as the argument."
+}

--- a/docker/scripts/ld.command.phpcs.sh
+++ b/docker/scripts/ld.command.phpcs.sh
@@ -26,4 +26,6 @@ function ld_command_phpcs_extended_help() {
     echo "Drupal and DrupalPractice coding standards will be supported as long as"
     echo "dealerdirect/phpcodesniffer-composer-installer package has been installed."
     echo "To target e.g. your custom modules, use /var/www/web/modules/custom as the argument."
+    echo
+    echo "Example: $SCRIPT_NAME_SHORT phpcs --standard=Drupal,DrupalPractice /var/www/web/modules/custom"
 }


### PR DESCRIPTION
The command offers a new extended_help function as well. This can be
utilized when the 'instruct' command PR has been merged.

Note that I am leaving phpcbf out of the scope of this PR on purpose, it is not an unintended omission. I have not had very good results trying to use phpcbf myself, hence the decision.

Example usage: 
```
$ ./ld phpcs --standard=Drupal /var/www/web/themes/custom/mytheme/mytheme.theme
Next: docker-compose exec php /var/www/vendor/bin/phpcs --standard=Drupal /var/www/web/themes/custom/mytheme/mytheme.theme

FILE: /var/www/web/themes/custom/mytheme/mytheme.theme
----------------------------------------------------------------------
FOUND 12 ERRORS AFFECTING 10 LINES
----------------------------------------------------------------------
  8 | ERROR | [x] Line indented incorrectly; expected 0 spaces, found
    |       |     1
  9 | ERROR | [x] Expected 2 space(s) before asterisk; 1 found
 10 | ERROR | [x] Expected 2 space(s) before asterisk; 1 found
 11 | ERROR | [x] Expected 2 space(s) before asterisk; 1 found
 11 | ERROR | [x] Doc comment long description must end with a full
    |       |     stop
 12 | ERROR | [x] Expected 2 space(s) before asterisk; 1 found
 13 | ERROR | [x] Expected 2 space(s) before asterisk; 1 found
 13 | ERROR | [x] Additional blank lines found at end of doc comment
 53 | ERROR | [x] Line indented incorrectly; expected 0 spaces, found
    |       |     1
 56 | ERROR | [x] Doc comment long description must end with a full
    |       |     stop
 58 | ERROR | [x] Additional blank lines found at end of doc comment
 68 | ERROR | [x] Namespaced classes/interfaces/traits should be
    |       |     referenced with use statements
----------------------------------------------------------------------
PHPCBF CAN FIX THE 12 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------

Time: 383ms; Memory: 10MB
```
