### PR TITLE
Configure domains per traefik labels

### DIFF
--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -42,8 +42,7 @@ services:
     build: ./docker/build/nginx
     container_name: "${PROJECT_NAME}_nginx"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`)"
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`www.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
     volumes:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -51,8 +51,7 @@ services:
       build: ./docker/build/nginx
       container_name: "${PROJECT_NAME}_nginx"
       labels:
-        - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`)"
-        - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`www.${LOCAL_DOMAIN}`)"
+        - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
       volumes:
         # :nocopy must be used with docker-sync
         # See bottom of this file, and ./docker-sync.yml

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -42,8 +42,7 @@ services:
     build: ./docker/build/nginx
     container_name: "${PROJECT_NAME}_nginx"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`)"
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`www.${LOCAL_DOMAIN}`)"
+        - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
     volumes:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -42,7 +42,7 @@ services:
     build: ./docker/build/nginx
     container_name: "${PROJECT_NAME}_nginx"
     labels:
-        - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+       - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
     volumes:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml

--- a/docker/scripts/ld.command.configure-network.sh
+++ b/docker/scripts/ld.command.configure-network.sh
@@ -27,7 +27,7 @@ function ld_command_configure-network_exec() {
     DOMAIN_SET=$(egrep -e $LOCAL_IP'\s*([a-z0-9\.-]*\s?\s*)*('$LOCAL_DOMAIN')' /etc/hosts)
     if [ "$LOCAL_DOMAIN" != "localhost" ]; then
         if [ -z "$DOMAIN_SET" ]; then
-            SUBDOMAINS=$(grep '=Host' docker-compose.yml | cut -d'`' -f2 | cut -d'.' -f1 | grep -v '\$' | xargs -I % echo %.${LOCAL_DOMAIN} | xargs)
+            SUBDOMAINS=$(egrep 'traefik\.[a-z]*\.routers..*\.rule\=Host\(' docker-compose.yml | grep -o '[a-z0-9\.]*\${LOCAL_DOMAIN\}'  | cut -d'.' -f1 | grep -v '^\$' | xargs -I % echo %.${LOCAL_DOMAIN} | xargs)
             echo -e "${Yellow}Adding domain $LOCAL_DOMAIN with subdomains to your hosts file to poin to $LOCAL_IP.${Color_Off}"
             echo -e "${BYellow}NOTE: This DNS record is not removed automatically.${Color_Off}"
             if [ -z "$SUDO_REQUESTED" ]; then

--- a/docker/scripts/ld.command.configure-network.sh
+++ b/docker/scripts/ld.command.configure-network.sh
@@ -27,6 +27,12 @@ function ld_command_configure-network_exec() {
     DOMAIN_SET=$(egrep -e $LOCAL_IP'\s*([a-z0-9\.-]*\s?\s*)*('$LOCAL_DOMAIN')' /etc/hosts)
     if [ "$LOCAL_DOMAIN" != "localhost" ]; then
         if [ -z "$DOMAIN_SET" ]; then
+            # Gather up all hostnames from docker-compose.yml file where
+            # - line has a string similar to: traefik.SOME-ROUTER-NAME.routers.SOME-STRING.rule=Host(`${LOCAL_DOMAIN}`) [egrep...],
+            # - grab only subdomains, but also multiple hits per line by printing out each match on its own line [grep -o...],
+            # - split lines by dot and take only the subdomain -part,
+            # - remove the line(s) starting with a $ (ie the like with nothing but "${LOCAL_DOMAIN}" in it),
+            # - add a dot and the actual domain (not the variable itself) after each of the subdomains
             SUBDOMAINS=$(egrep 'traefik\.[a-z]*\.routers..*\.rule\=Host\(' docker-compose.yml | grep -o '[a-z0-9\.]*\${LOCAL_DOMAIN\}'  | cut -d'.' -f1 | grep -v '^\$' | xargs -I % echo %.${LOCAL_DOMAIN} | xargs)
             echo -e "${Yellow}Adding domain $LOCAL_DOMAIN with subdomains to your hosts file to poin to $LOCAL_IP.${Color_Off}"
             echo -e "${BYellow}NOTE: This DNS record is not removed automatically.${Color_Off}"


### PR DESCRIPTION
Correnct faulty nginx router rules fro Traefik (only one Host() rule works), and gather all configured router hostnames even if set in the same line.