### PR TITLE
Add cached sync strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ and start the initialisation.
     $ git branch -D master
     $ git branch -m master-new master
     $ git push
-    $ ./ld init
+    $ ./ld init [TEMPLATE-NAME]
 
 #### Existing project
 
@@ -81,7 +81,7 @@ an error, ensure `ld.sh` has execute permission:
 
 Initial setup asks if you some generic information.
 
-    $ ./ld init
+    $ ./ld init [TEMPLATE-NAME]
 
 If you are applying `local-docker` on a Skeleton -based project, see
 "Skeleton" -section .
@@ -89,7 +89,7 @@ If you are applying `local-docker` on a Skeleton -based project, see
 ### Local domains
 
 `./ld init` sets up your local IP addresses and domains. You'll be asked
-for a local development domain among ohter things, and `local-docker`
+for a local development domain among other things, and `local-docker`
 will write a `/etc/hosts` -record for you and maintain localhost IP
 address aliases.
 
@@ -193,9 +193,12 @@ keeping most recent as the restorable dump.
 
 It is recommended to start the project first time with:
 
-    $ ./ld init
+    $ ./ld init [TEMPLATE-NAME]
 
 and answer some question to set up things properly.
+
+The template name must match the
+`docker/docker-compose.TEMPLATE-NAME.yml` template file names.
 
 #### Start local
 

--- a/docker/docker-compose.cached.yml
+++ b/docker/docker-compose.cached.yml
@@ -1,4 +1,7 @@
-# Template: docker-compose.common.yml
+# Template: docker-compose.cached.yml
+#
+# This file sets up containers using volumes with cached mounts. Page loads are a slower
+# but starting up a project is nearly instantaneous.
 
 version: '3.3'
 

--- a/docker/docker-compose.cached.yml
+++ b/docker/docker-compose.cached.yml
@@ -1,0 +1,181 @@
+# Template: docker-compose.common.yml
+
+version: '3.3'
+
+services:
+
+  # @see https://github.com/containous/blog-posts/blob/master/2019_09_10-101_docker/docker-compose-09.yml
+  traefik:
+    image: "traefik:v2.0.0"
+    container_name: "${PROJECT_NAME}_traefik"
+    ports:
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB}:80"
+    labels:
+      # Dashboard
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.service=api@internal"
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.entrypoints=web"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    restart: on-failure
+    command:
+      # NOTE: entrypoints.XX.address MUST NOT contain IP, but only port.
+      - "--entrypoints.web.address=:${CONTAINER_PORT_WEB}"
+      - --providers.docker
+      - --api
+      - --api.insecure=true
+      - --api.debug=true
+
+  whoami:
+    image: containous/whoami:v1.3.0
+    container_name: "${PROJECT_NAME}_whoami"
+    labels:
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-whoami.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+    restart: on-failure
+
+  nginx:
+    build: ./docker/build/nginx
+    container_name: "${PROJECT_NAME}_nginx"
+    labels:
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+    volumes:
+      # :cached must be used with docker-sync
+      # See bottom of this file, and ./docker-sync.yml
+      - ./${APP_ROOT}:/var/www:cached
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    depends_on: # This key affects the order of which containers get started.
+      - php
+    restart: on-failure
+    working_dir: /var/www/web
+
+  php:
+    # Available builds: https://hub.docker.com/r/xoxoxo/php-container/tags
+    # Custom build contains sendmail_path -fix for Mailhog and OPTION to add
+    # overrides (per project) to other PHP config.
+    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
+    container_name: "${PROJECT_NAME}_php"
+    volumes:
+      # :cached must be used with docker-sync
+      # See bottom of this file, and ./docker-sync.yml
+      - ./${APP_ROOT}:/var/www:cached
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    restart: on-failure
+    working_dir: /var/www
+
+  composer:
+    # Runs `composer install` during startup.
+    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
+    container_name: "${PROJECT_NAME}_composer"
+    volumes:
+      # This share gets writes from within the container by Composer.
+      # :cached must be used with docker-sync
+      # See bottom of this file, and ./docker-sync.yml
+      - ./${APP_ROOT}:/var/www:cached
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    restart: on-failure
+    working_dir: /var/www
+    command: sh -c '[[ "$CONTAINER_COMPOSER_START" -ne "1" ]] && echo "Container 'composer' disabled." && exit 0 ||  [[ ! -e "/var/www/composer.lock" ]] && echo "File /var/www/composer.lock not present, exiting." && exit 0 || /usr/local/bin/composer install'
+
+  db:
+    # mysql:8.0.11 keeps restarting.
+    image: mysql:5.7.26
+    container_name: "${PROJECT_NAME}_db"
+    ports:
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_DB:-3306}:3306"
+    volumes:
+      # This folder contains database dumps (mostly written by container).
+      # :cached must be used with docker-sync
+      # See bottom of this file, and ./docker-sync.yml
+      - ./db_dumps:/var/db_dumps:cached
+      # Named volume for db table data. Docker keeps this volume around
+      # unless stack is down'ed with "--volumes":
+      # $ docker-compose down --volumes
+      - db_data:/var/lib/mysql
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    restart: on-failure
+    working_dir: /var
+    # Set max_allowed_packet to 256M (or any other value)
+    command: --max_allowed_packet=268435456
+
+  # Maybe use this instead of the one set blow here: https://hub.docker.com/r/eeacms/varnish/
+  # varnish:
+  #   image: jonbaldie/varnish:8056b94
+  #   ports:
+  #     - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_VARNISH:-8017}:80"
+
+  solr:
+    image: solr:8.2.0
+    container_name: "${PROJECT_NAME}_solr"
+    labels:
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-solr.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+    volumes:
+      - solr_data:/var/solr
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    restart: on-failure
+    command:
+      - solr-precreate
+      - gettingstarted
+
+  adminer:
+    image: adminer:4.7.3
+    container_name: "${PROJECT_NAME}_adminer"
+    labels:
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-db-client.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+    restart: on-failure
+
+  # PHP container needs some Mailhog -configuration.
+  mailhog:
+    image: mailhog/mailhog:v1.0.0
+    container_name: "${PROJECT_NAME}_mailhog"
+    labels:
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      # https://docs.traefik.io/routing/providers/docker/#service-definition
+      - "traefik.http.services.${PROJECT_NAME}--mailhog.loadbalancer.server.port=8025"
+    restart: on-failure
+
+  # Replace MYTHEME with your theme name. If you have multiple the
+  # clone the noodejs -section and rename the containers to something like
+  # - nodejs_mytheme and
+  # - nodejs_my_other_theme.
+  nodejs:
+    image: wodby/drupal-node:1.0-1.0.0
+    container_name: "${PROJECT_NAME}_nodejs"
+    volumes:
+      - ./${APP_ROOT}:/var/www:cached
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    restart: on-failure
+    working_dir: /var/www
+    command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+
+volumes:
+  db_data: {}
+  solr_data: {}

--- a/docker/docker-compose.cached.yml
+++ b/docker/docker-compose.cached.yml
@@ -1,6 +1,6 @@
 # Template: docker-compose.cached.yml
 #
-# This file sets up containers using volumes with cached mounts. Page loads are a slower
+# This file sets up containers using volumes with cached mounts. Page loads are slower
 # but starting up a project is nearly instantaneous.
 
 version: '3.3'

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -103,7 +103,7 @@ services:
       # This folder contains database dumps (mostly written by container).
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
-      - webroot-nfs-dbdumps:/var/db_dumps
+      - ./db_dumps:/var/db_dumps:cached
       # Named volume for db table data. Docker keeps this volume around
       # unless stack is down'ed with "--volumes":
       # $ docker-compose down --volumes
@@ -179,11 +179,5 @@ services:
 volumes:
   webroot-sync-core:
     external: true
-  webroot-nfs-dbdumps:
-    driver: local
-    driver_opts:
-      type: nfs
-      o: addr=host.docker.internal,rw,nolock,nfsvers=3
-      device: ":${PWD}/${DATABASE_DUMP_STORAGE:-db_dumps}"
   db_data: {}
   solr_data: {}

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -1,4 +1,7 @@
 # Template: docker-compose.common.yml
+#
+# This file sets up containers using docker-sync (intermediate sync containers)
+# for page load performance, but causes start up time delay up to a few minutes.
 
 version: '3.3'
 

--- a/docker/docker-compose.ddev.yml
+++ b/docker/docker-compose.ddev.yml
@@ -1,4 +1,8 @@
-# Template: docker-compose.common.yml
+# Template: docker-compose.ddev.yml
+#
+# This file sets up containers using docker-sync (intermediate sync containers)
+# for page load performance, but causes start up time delay up to a few minutes.
+# 1:1 clone from the common template.
 
 version: '3.3'
 

--- a/docker/docker-compose.ddev.yml
+++ b/docker/docker-compose.ddev.yml
@@ -1,0 +1,183 @@
+# Template: docker-compose.common.yml
+
+version: '3.3'
+
+services:
+
+  # @see https://github.com/containous/blog-posts/blob/master/2019_09_10-101_docker/docker-compose-09.yml
+  traefik:
+    image: "traefik:v2.0.0"
+    container_name: "${PROJECT_NAME}_traefik"
+    ports:
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB}:80"
+    labels:
+      # Dashboard
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.service=api@internal"
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.entrypoints=web"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    restart: on-failure
+    command:
+      # NOTE: entrypoints.XX.address MUST NOT contain IP, but only port.
+      - "--entrypoints.web.address=:${CONTAINER_PORT_WEB}"
+      - --providers.docker
+      - --api
+      - --api.insecure=true
+      - --api.debug=true
+
+  whoami:
+    image: containous/whoami:v1.3.0
+    container_name: "${PROJECT_NAME}_whoami"
+    labels:
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-whoami.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+    restart: on-failure
+
+  nginx:
+    build: ./docker/build/nginx
+    container_name: "${PROJECT_NAME}_nginx"
+    labels:
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+    volumes:
+      # :nocopy must be used with docker-sync
+      # See bottom of this file, and ./docker-sync.yml
+      - webroot-sync-core:/var/www:nocopy
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    depends_on: # This key affects the order of which containers get started.
+      - php
+    restart: on-failure
+    working_dir: /var/www/web
+
+  php:
+    # Available builds: https://hub.docker.com/r/xoxoxo/php-container/tags
+    # Custom build contains sendmail_path -fix for Mailhog and OPTION to add
+    # overrides (per project) to other PHP config.
+    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
+    container_name: "${PROJECT_NAME}_php"
+    volumes:
+      # :nocopy must be used with docker-sync
+      # See bottom of this file, and ./docker-sync.yml
+      - webroot-sync-core:/var/www:nocopy
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    restart: on-failure
+    working_dir: /var/www
+
+  composer:
+    # Runs `composer install` during startup.
+    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
+    container_name: "${PROJECT_NAME}_composer"
+    volumes:
+      # This share gets writes from within the container by Composer.
+      # :nocopy must be used with docker-sync
+      # See bottom of this file, and ./docker-sync.yml
+      - webroot-sync-core:/var/www:nocopy
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    restart: on-failure
+    working_dir: /var/www
+    command: sh -c '[[ "$CONTAINER_COMPOSER_START" -ne "1" ]] && echo "Container 'composer' disabled." && exit 0 ||  [[ ! -e "/var/www/composer.lock" ]] && echo "File /var/www/composer.lock not present, exiting." && exit 0 || /usr/local/bin/composer install'
+
+  db:
+    # mysql:8.0.11 keeps restarting.
+    image: mysql:5.7.26
+    container_name: "${PROJECT_NAME}_db"
+    ports:
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_DB:-3306}:3306"
+    volumes:
+      # This folder contains database dumps (mostly written by container).
+      # :nocopy must be used with docker-sync
+      # See bottom of this file, and ./docker-sync.yml
+      - ./db_dumps:/var/db_dumps:cached
+      # Named volume for db table data. Docker keeps this volume around
+      # unless stack is down'ed with "--volumes":
+      # $ docker-compose down --volumes
+      - db_data:/var/lib/mysql
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    restart: on-failure
+    working_dir: /var
+    # Set max_allowed_packet to 256M (or any other value)
+    command: --max_allowed_packet=268435456
+
+  # Maybe use this instead of the one set blow here: https://hub.docker.com/r/eeacms/varnish/
+  # varnish:
+  #   image: jonbaldie/varnish:8056b94
+  #   ports:
+  #     - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_VARNISH:-8017}:80"
+
+  solr:
+    image: solr:8.2.0
+    container_name: "${PROJECT_NAME}_solr"
+    labels:
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-solr.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+    volumes:
+      - solr_data:/var/solr
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    restart: on-failure
+    command:
+      - solr-precreate
+      - gettingstarted
+
+  adminer:
+    image: adminer:4.7.3
+    container_name: "${PROJECT_NAME}_adminer"
+    labels:
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-db-client.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+    restart: on-failure
+
+  # PHP container needs some Mailhog -configuration.
+  mailhog:
+    image: mailhog/mailhog:v1.0.0
+    container_name: "${PROJECT_NAME}_mailhog"
+    labels:
+      - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      # https://docs.traefik.io/routing/providers/docker/#service-definition
+      - "traefik.http.services.${PROJECT_NAME}--mailhog.loadbalancer.server.port=8025"
+    restart: on-failure
+
+  # Replace MYTHEME with your theme name. If you have multiple the
+  # clone the noodejs -section and rename the containers to something like
+  # - nodejs_mytheme and
+  # - nodejs_my_other_theme.
+  nodejs:
+    image: wodby/drupal-node:1.0-1.0.0
+    container_name: "${PROJECT_NAME}_nodejs"
+    volumes:
+      - webroot-sync-core:/var/www:nocopy
+    # In case of several env files later declared variable
+    # values override earlier ones
+    env_file:
+      - .env
+      - .env.local
+    restart: on-failure
+    working_dir: /var/www
+    command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+
+volumes:
+  webroot-sync-core:
+    external: true
+  db_data: {}
+  solr_data: {}

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -110,7 +110,7 @@ services:
       # This folder contains database dumps (mostly written by container).
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
-      - webroot-nfs-dbdumps:/var/db_dumps
+      - ./db_dumps:/var/db_dumps:cached
       # Named volume for db table data. Docker keeps this volume around
       # unless stack is down'ed with "--volumes":
       # $ docker-compose down --volumes
@@ -194,11 +194,5 @@ volumes:
     external: true
   webroot-sync-src-themes:
     external: true
-  webroot-nfs-dbdumps:
-    driver: local
-    driver_opts:
-      type: nfs
-      o: addr=host.docker.internal,rw,nolock,nfsvers=3
-      device: ":${PWD}/${DATABASE_DUMP_STORAGE:-db_dumps}"
   db_data: {}
   solr_data: {}

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -1,4 +1,7 @@
 # Template: docker-compose.skeleton.yml
+#
+# This file sets up containers using docker-sync (intermediate sync containers)
+# for page load performance, but causes start up time delay up to a few minutes.
 
 version: '3.3'
 

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -23,7 +23,7 @@ function ld_command_init_exec() {
     # Project type, defaults to common.
     TYPE=${1:-'common'}
     # Read all template files available for whitelist
-    WHITELIST_TYPES=$(ls docker/docker-compose.*.yml | cut -d'.' -f2 |xargs)
+    WHITELIST_TYPES=$(find ./docker -maxdepth 1 -name 'docker-compose.*.yml' | cut -d'/' -f3 | cut -d'.' -f2 | xargs)
     if [[ " ${WHITELIST_TYPES[@]} " != *" $TYPE "* ]]; then
         echo
         echo -e "${Red}The requested template ${BRed}\"$TYPE\"${Red} is not available.. ${Color_Off}"

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -23,7 +23,7 @@ function ld_command_init_exec() {
     # Project type, defaults to common.
     TYPE=${1:-'common'}
     # Read all template files available for whitelist.
-    WHITELIST_TYPES=$(find ./docker -maxdepth 1 -name 'docker-compose.*.yml' -print0 | xargs -0 basename | cut -d'.' -f2 | xargs)
+    WHITELIST_TYPES=$(find ./docker -maxdepth 1 -name 'docker-compose.*.yml' -print0 | xargs -0 basename -a | cut -d'.' -f2 | xargs)
     if [[ " ${WHITELIST_TYPES[@]} " != *" $TYPE "* ]]; then
         echo
         echo -e "${Red}The requested template ${BRed}\"$TYPE\"${Red} is not available.. ${Color_Off}"

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -22,8 +22,8 @@ function ld_command_init_exec() {
 
     # Project type, defaults to common.
     TYPE=${1:-'common'}
-    # Read all template files available for whitelist
-    WHITELIST_TYPES=$(find ./docker -maxdepth 1 -name 'docker-compose.*.yml' | cut -d'/' -f3 | cut -d'.' -f2 | xargs)
+    # Read all template files available for whitelist.
+    WHITELIST_TYPES=$(find ./docker -maxdepth 1 -name 'docker-compose.*.yml' -print0 | xargs -0 basename | cut -d'.' -f2 | xargs)
     if [[ " ${WHITELIST_TYPES[@]} " != *" $TYPE "* ]]; then
         echo
         echo -e "${Red}The requested template ${BRed}\"$TYPE\"${Red} is not available.. ${Color_Off}"

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -179,10 +179,12 @@ function ld_command_init_exec() {
     echo "Verify application root can be used to install codebase (must be empty)..."
 
     DELETION_ASKED=0
-    echo "Files (count) in ./$APP_ROOT: "$(ls -A $APP_ROOT | wc -l | tr -d ' ')
+    APP_FILES_COUNT=$([ -e ./$APP_ROOT ] && find ./$APP_ROOT -print -maxdepth 1 | wc -l | tr -d ' ' || echo 0)
+    echo "Files (count) in ./$APP_ROOT: $APP_FILES_COUNT"
 
-    if [ "$(ls -A $APP_ROOT | wc -l | tr -d ' ')" -ne "0" ]; then
-        echo "Application root folder $APP_ROOT is not empty. Installation requires an empty folder. Currently there is: "
+    if [ "$APP_FILES_COUNT" -ne "0" ]; then
+        echo "Application root folder ./$APP_ROOT is not empty. Installation requires an empty folder."
+        echo "Current folder contents:"
         ls -A $APP_ROOT
         echo -en "${Red}WARNING: If you continue all of these will be deleted. ${Color_Off}"
         read -p "Type 'PLEASE-DELETE' to continue: " CHOICE

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -4,10 +4,7 @@
 # This file contains init -command for local-docker script ld.sh.
 
 function ld_command_init_exec() {
-    check_if_project_needs_initialization
-    NEEDS_INITIALIZATION=$?
-
-    if [ "${NEEDS_INITIALIZATION}" -eq "0" ]; then
+    if ! project_config_file_check; then
         echo -e "${BRed}This project is already initialized. ${Color_Off}"
         echo -e "${Yellow}Are you really sure you want to re-initialize the project? ${Color_Off}"
         read -p "[yes/NO] " ANSWER
@@ -106,7 +103,7 @@ function ld_command_init_exec() {
     echo -e "${BYellow}Using PHP version: $PROJECT_PHP_VERSION.${Color_Off}"
 
     # 2nd param, project type.
-    TYPE=${1-'common'}
+    TYPE=${1:-'common'}
     # Suggest Skeleton cleanup only when it is relevant.
     if [ -e "$DOCKERSYNC_FILE" ] || [ -e "$DOCKER_COMPOSE_FILE" ]; then
         echo -e "${BYellow}WARNING: There is docker-compose and/or docker-sync recipies in project root.${Color_Off}"

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -4,6 +4,7 @@
 # This file contains init -command for local-docker script ld.sh.
 
 function ld_command_init_exec() {
+
     if ! project_config_file_check; then
         echo -e "${BRed}This project is already initialized. ${Color_Off}"
         echo -e "${Yellow}Are you really sure you want to re-initialize the project? ${Color_Off}"
@@ -18,6 +19,19 @@ function ld_command_init_exec() {
               ;;
         esac
     fi
+
+    # Project type, defaults to common.
+    TYPE=${1:-'common'}
+    # Read all template files available for whitelist
+    WHITELIST_TYPES=$(ls docker/docker-compose.*.yml | cut -d'.' -f2 |xargs)
+    if [[ " ${WHITELIST_TYPES[@]} " != *" $TYPE "* ]]; then
+        echo
+        echo -e "${Red}The requested template ${BRed}\"$TYPE\"${Red} is not available.. ${Color_Off}"
+        echo -e "${Yellow}Available templates include: ${WHITELIST_TYPES[@]}. ${Color_Off}"
+        echo
+        exit 1
+    fi
+
 
     VALID=0
     while [ "$VALID" -eq "0" ]; do
@@ -102,8 +116,6 @@ function ld_command_init_exec() {
     define_configuration_value PROJECT_PHP_VERSION $PROJECT_PHP_VERSION
     echo -e "${BYellow}Using PHP version: $PROJECT_PHP_VERSION.${Color_Off}"
 
-    # 2nd param, project type.
-    TYPE=${1:-'common'}
     # Suggest Skeleton cleanup only when it is relevant.
     if [ -e "$DOCKERSYNC_FILE" ] || [ -e "$DOCKER_COMPOSE_FILE" ]; then
         echo -e "${BYellow}WARNING: There is docker-compose and/or docker-sync recipies in project root.${Color_Off}"
@@ -120,7 +132,7 @@ function ld_command_init_exec() {
 
     # Skeleton uses different folder as the main location for app code.
     [[ "$TYPE" == "skeleton" ]] &&  APP_ROOT='drupal'
-    [[ "$TYPE" == "ddev" ]] &&  APP_ROOT='.' && TYPE="common"
+    [[ "$TYPE" == "ddev" ]] &&  APP_ROOT='.'
 
     yml_move $TYPE
     if [ "$?" -eq "1" ]; then

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -151,14 +151,11 @@ function create_project_config_file() {
   fi
 
   if [ ! -f "$FILE" ]; then
-    echo -e "${Green}Creating default ${BGreen}${FILE}${Green} file from the template. ${Color_Off}"
     cp -f ${TEMPLATE} ${FILE}
   else
     echo -e "${Yellow}Adding default values from ${TEMPLATE} file to your ${BYellow}EXISTING${Yellow} ${BYellow}${FILE}${Yellow} file. ${Color_Off}"
     cat ${TEMPLATE} >> ${FILE}
   fi
-
-  echo -e "${Yellow}Your ${FILE} file ${BYellow}should be committed to Git repository${Yellow}.${Color_Off}"
 }
 
 function function_exists() {

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -242,19 +242,14 @@ element_in () {
 
 
 # Checks if project is initialized.
-# Prints 1 for is-initialized, 0 for not-yet-initialized.
-# return values: 0 initialized, 1 non-initialized
-check_if_project_needs_initialization () {
-    FILES_MISSING=0
-    if [ ! -f ".env" ] ; then
-        FILES_MISSING=1
-    fi
-    if [ ! -f "$DOCKERSYNC_FILE" ] ; then
-        FILES_MISSING=1
-    fi
-    if [ ! -f "$DOCKER_COMPOSE_FILE" ]; then
-        FILES_MISSING=1
+# @return
+# - 1 when config files are present
+# - 0 when only .env file is present (for cases where init is done with prepared .env file).
+project_config_file_check () {
+    # Both .env AND docker-compose.yml file must be present to define project as initialized.
+    if [ -f ".env" ] && ( [ -f "$DOCKERSYNC_FILE" ] || [ -f "$DOCKER_COMPOSE_FILE" ] ); then
+        return 1
     fi
 
-    return $FILES_MISSING
+    return 0
  }

--- a/ld.sh
+++ b/ld.sh
@@ -57,6 +57,10 @@ if [ "$?" -eq "0" ]; then
 fi
 
 # Read (and create if necessary) the .env.local file, allowing overrides to any of our config values.
+if [ "$ACTION" == "init" ]; then
+    import_config
+fi
+
 if [  "$IGNORE_INIT_STATE" -eq "0" ]; then
     if project_config_file_check; then
         echo -e "${BYellow}This project is not yet initialized. ${Color_Off}"

--- a/ld.sh
+++ b/ld.sh
@@ -49,18 +49,16 @@ else
     SCRIPT_NAME_SHORT=./$( basename "$0" .sh)
 fi
 
-IGNORE_INIT_STATE=
-WHITELIST_COMMANDS=("help" "self-update")
+IGNORE_INIT_STATE=0
+WHITELIST_COMMANDS=("help" "self-update" "init")
 element_in "$ACTION" "${WHITELIST_COMMANDS[@]}"
 if [ "$?" -eq "0" ]; then
     IGNORE_INIT_STATE=1
 fi
 
 # Read (and create if necessary) the .env.local file, allowing overrides to any of our config values.
-if [ -z "$IGNORE_INIT_STATE" ] || [  "$IGNORE_INIT_STATE" -eq "0" ]; then
-    check_if_project_needs_initialization
-    NEEDS_INITIALIZATION=$?
-    if [ "${NEEDS_INITIALIZATION}" -eq "1" ] && [ "$ACTION" != "init" ]; then
+if [  "$IGNORE_INIT_STATE" -eq "0" ]; then
+    if project_config_file_check; then
         echo -e "${BYellow}This project is not yet initialized. ${Color_Off}"
         echo -e "${Yellow}Initialize the project with: ${Color_Off}"
         echo -e "\$ ${SCRIPT_NAME_SHORT} init"


### PR DESCRIPTION
This PR makes init -command to check the template name (against the existing docker-compose file tempaltes present), and removes NFS from common & skeleton -templates (in favor of slower yet much more robust native `./local-dir:/container-dir:cached` volume mounts)