### PR TITLE
Better node container for gulp watcher

### DIFF
--- a/docker/docker-compose.cached.yml
+++ b/docker/docker-compose.cached.yml
@@ -162,21 +162,22 @@ services:
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the
-  # clone the noodejs -section and rename the containers to something like
-  # - nodejs_mytheme and
-  # - nodejs_my_other_theme.
-  nodejs:
-    image: wodby/drupal-node:1.0-1.0.0
-    container_name: "${PROJECT_NAME}_nodejs"
+  # clone this section and rename the containers to something like
+  # - nodejs_othertheme.
+  # - nodejs_thirdtheme etc.
+  nodejs_MYTHEME:
+    image: "node:11"
+    container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - ./${APP_ROOT}:/var/www:cached
+      - nodemodules:/var/www/web/themes/custom/MYTHEME/node_modules
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
       - .env
       - .env.local
     restart: on-failure
-    working_dir: /var/www
+    working_dir: /var/www/web/themes/custom/MYTHEME/
     command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:

--- a/docker/docker-compose.cached.yml
+++ b/docker/docker-compose.cached.yml
@@ -183,3 +183,4 @@ services:
 volumes:
   db_data: {}
   solr_data: {}
+  nodemodules: {}

--- a/docker/docker-compose.cached.yml
+++ b/docker/docker-compose.cached.yml
@@ -166,7 +166,7 @@ services:
   # - nodejs_othertheme.
   # - nodejs_thirdtheme etc.
   nodejs_MYTHEME:
-    image: "node:11"
+    image: node:11
     container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - ./${APP_ROOT}:/var/www:cached

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -162,21 +162,22 @@ services:
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the
-  # clone the noodejs -section and rename the containers to something like
-  # - nodejs_mytheme and
-  # - nodejs_my_other_theme.
-  nodejs:
-    image: wodby/drupal-node:1.0-1.0.0
-    container_name: "${PROJECT_NAME}_nodejs"
+  # clone this section and rename the containers to something like
+  # - nodejs_othertheme.
+  # - nodejs_thirdtheme etc.
+  nodejs_MYTHEME:
+    image: "node:11"
+    container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - webroot-sync-core:/var/www:nocopy
+      - nodemodules:/var/www/web/themes/custom/MYTHEME/node_modules
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
       - .env
       - .env.local
     restart: on-failure
-    working_dir: /var/www
+    working_dir: /var/www/web/themes/custom/MYTHEME/
     command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -166,7 +166,7 @@ services:
   # - nodejs_othertheme.
   # - nodejs_thirdtheme etc.
   nodejs_MYTHEME:
-    image: "node:11"
+    image: node:11
     container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - webroot-sync-core:/var/www:nocopy

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -185,3 +185,4 @@ volumes:
     external: true
   db_data: {}
   solr_data: {}
+  nodemodules: {}

--- a/docker/docker-compose.ddev.yml
+++ b/docker/docker-compose.ddev.yml
@@ -186,3 +186,4 @@ volumes:
     external: true
   db_data: {}
   solr_data: {}
+  nodemodules: {}

--- a/docker/docker-compose.ddev.yml
+++ b/docker/docker-compose.ddev.yml
@@ -163,21 +163,22 @@ services:
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the
-  # clone the noodejs -section and rename the containers to something like
-  # - nodejs_mytheme and
-  # - nodejs_my_other_theme.
-  nodejs:
-    image: wodby/drupal-node:1.0-1.0.0
-    container_name: "${PROJECT_NAME}_nodejs"
+  # clone this section and rename the containers to something like
+  # - nodejs_othertheme.
+  # - nodejs_thirdtheme etc.
+  nodejs_MYTHEME:
+    image: "node:11"
+    container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - webroot-sync-core:/var/www:nocopy
+      - nodemodules:/var/www/web/themes/custom/MYTHEME/node_modules
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
       - .env
       - .env.local
     restart: on-failure
-    working_dir: /var/www
+    working_dir: /var/www/web/themes/custom/MYTHEME/
     command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:

--- a/docker/docker-compose.ddev.yml
+++ b/docker/docker-compose.ddev.yml
@@ -167,7 +167,7 @@ services:
   # - nodejs_othertheme.
   # - nodejs_thirdtheme etc.
   nodejs_MYTHEME:
-    image: "node:11"
+    image: node:11
     container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - webroot-sync-core:/var/www:nocopy

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -168,7 +168,7 @@ services:
   # - nodejs_othertheme.
   # - nodejs_thirdtheme etc.
   nodejs_MYTHEME:
-    image: "node:11"
+    image: node:11
     container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - webroot-nfs-app:/var/www:nocopy

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -197,3 +197,4 @@ volumes:
       device: ":${PWD}/${DATABASE_DUMP_STORAGE:-db_dumps}"
   db_data: {}
   solr_data: {}
+  nodemodules: {}

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -164,21 +164,22 @@ services:
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the
-  # clone the noodejs -section and rename the containers to something like
-  # - nodejs_mytheme and
-  # - nodejs_my_other_theme.
-  nodejs:
-    image: wodby/drupal-node:1.0-1.0.0
-    container_name: "${PROJECT_NAME}_nodejs"
+  # clone this section and rename the containers to something like
+  # - nodejs_othertheme.
+  # - nodejs_thirdtheme etc.
+  nodejs_MYTHEME:
+    image: "node:11"
+    container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
-      - webroot-nfs-app:/var/www
+      - webroot-nfs-app:/var/www:nocopy
+      - nodemodules:/var/www/web/themes/custom/MYTHEME/node_modules
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
       - .env
       - .env.local
     restart: on-failure
-    working_dir: /var/www
+    working_dir: /var/www/web/themes/custom/MYTHEME/
     command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -173,7 +173,7 @@ services:
   # - nodejs_othertheme.
   # - nodejs_thirdtheme etc.
   nodejs_MYTHEME:
-    image: "node:11"
+    image: node:11
     container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - webroot-sync-core:/var/www:nocopy

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -169,21 +169,22 @@ services:
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the
-  # clone the noodejs -section and rename the containers to something like
-  # - nodejs_mytheme and
-  # - nodejs_my_other_theme.
-  nodejs:
-    image: wodby/drupal-node:1.0-1.0.0
-    container_name: "${PROJECT_NAME}_nodejs"
+  # clone this section and rename the containers to something like
+  # - nodejs_othertheme.
+  # - nodejs_thirdtheme etc.
+  nodejs_MYTHEME:
+    image: "node:11"
+    container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - webroot-sync-core:/var/www:nocopy
+      - nodemodules:/var/www/web/themes/custom/MYTHEME/node_modules
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
       - .env
       - .env.local
     restart: on-failure
-    working_dir: /var/www
+    working_dir: /var/www/web/themes/custom/MYTHEME/
     command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -200,3 +200,4 @@ volumes:
     external: true
   db_data: {}
   solr_data: {}
+  nodemodules: {}


### PR DESCRIPTION
Change Node base image to the official Node container.

Watching docker-compose logs displays the process (both installation of `npm install` and the `gulp watch` when it starts watching and compiling. 