### PR TITLE
Issue 127 move drupal sites xx files folders out of docker sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,6 @@ CONTAINER_DB=db
 CONTAINER_PHP=php
 CONTAINER_NGINX=nginx
 
-# Set value to 1 to use composer container (checked before the command is run)
-CONTAINER_COMPOSER_START=0
 # Set value to 1 to use nodejs (checked before the command is run)
 CONTAINER_NODEJS_START=0
 

--- a/docker/docker--composer-only.yml
+++ b/docker/docker--composer-only.yml
@@ -1,4 +1,4 @@
-# File: docker--compose-only.yml
+# File: docker--composer-only.yml
 #
 # This file is used only for temporary purposes, mainly - if not only - during
 # project init phase.
@@ -24,4 +24,3 @@ services:
       - ../.env.local
     restart: on-failure
     working_dir: /var/www
-

--- a/docker/docker--composer-only.yml
+++ b/docker/docker--composer-only.yml
@@ -1,0 +1,27 @@
+# File: docker--compose-only.yml
+#
+# This file is used only for temporary purposes, mainly - if not only - during
+# project init phase.
+
+version: '3.3'
+
+services:
+  composer:
+    # Runs `composer install` during startup.
+    build: ../docker/build/php/${PROJECT_PHP_VERSION:-7.3}
+    container_name: "${PROJECT_NAME}_composer"
+    volumes:
+      # Declaring only one volume with on volumes within allows building
+      # the codebase into a folder with nothing inside (where as overlapping
+      # volumes do appear as files and can't be removed).
+      # Locations are calculated from where this file is in filesystem.
+      - ../${APP_ROOT}:/var/www:delegated
+    env_file:
+      # In case of several env files later declared variable
+      # values override earlier ones
+      # Locations are calculated from where this file is in filesystem.
+      - ../.env
+      - ../.env.local
+    restart: on-failure
+    working_dir: /var/www
+

--- a/docker/docker-compose.cached.yml
+++ b/docker/docker-compose.cached.yml
@@ -50,6 +50,7 @@ services:
       # :cached must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
       - ./${APP_ROOT}:/var/www:cached
+      - ./${APP_ROOT}/web/sites/default/files:/var/www/web/sites/default/files:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -70,6 +71,7 @@ services:
       # :cached must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
       - ./${APP_ROOT}:/var/www:cached
+      - ./${APP_ROOT}/web/sites/default/files:/var/www/web/sites/default/files:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -152,6 +154,7 @@ services:
     container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - ./${APP_ROOT}:/var/www:cached
+      - ./${APP_ROOT}/web/sites/default/files:/var/www/web/sites/default/files:delegated
       - nodemodules:/var/www/web/themes/custom/MYTHEME/node_modules
     # In case of several env files later declared variable
     # values override earlier ones

--- a/docker/docker-compose.cached.yml
+++ b/docker/docker-compose.cached.yml
@@ -78,24 +78,6 @@ services:
     restart: on-failure
     working_dir: /var/www
 
-  composer:
-    # Runs `composer install` during startup.
-    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
-    container_name: "${PROJECT_NAME}_composer"
-    volumes:
-      # This share gets writes from within the container by Composer.
-      # :cached must be used with docker-sync
-      # See bottom of this file, and ./docker-sync.yml
-      - ./${APP_ROOT}:/var/www:cached
-    # In case of several env files later declared variable
-    # values override earlier ones
-    env_file:
-      - .env
-      - .env.local
-    restart: on-failure
-    working_dir: /var/www
-    command: sh -c '[[ "$CONTAINER_COMPOSER_START" -ne "1" ]] && echo "Container 'composer' disabled." && exit 0 ||  [[ ! -e "/var/www/composer.lock" ]] && echo "File /var/www/composer.lock not present, exiting." && exit 0 || /usr/local/bin/composer install'
-
   db:
     # mysql:8.0.11 keeps restarting.
     image: mysql:5.7.26

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -50,6 +50,7 @@ services:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
       - webroot-sync-core:/var/www:nocopy
+      - ./${APP_ROOT}/web/sites/default/files:/var/www/web/sites/default/files:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -70,6 +71,7 @@ services:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
       - webroot-sync-core:/var/www:nocopy
+      - ./${APP_ROOT}/web/sites/default/files:/var/www/web/sites/default/files:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -152,6 +154,7 @@ services:
     container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - webroot-sync-core:/var/www:nocopy
+      - ./${APP_ROOT}/web/sites/default/files:/var/www/web/sites/default/files:delegated
       - nodemodules:/var/www/web/themes/custom/MYTHEME/node_modules
     # In case of several env files later declared variable
     # values override earlier ones

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -78,24 +78,6 @@ services:
     restart: on-failure
     working_dir: /var/www
 
-  composer:
-    # Runs `composer install` during startup.
-    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
-    container_name: "${PROJECT_NAME}_composer"
-    volumes:
-      # This share gets writes from within the container by Composer.
-      # :nocopy must be used with docker-sync
-      # See bottom of this file, and ./docker-sync.yml
-      - webroot-sync-core:/var/www:nocopy
-    # In case of several env files later declared variable
-    # values override earlier ones
-    env_file:
-      - .env
-      - .env.local
-    restart: on-failure
-    working_dir: /var/www
-    command: sh -c '[[ "$CONTAINER_COMPOSER_START" -ne "1" ]] && echo "Container 'composer' disabled." && exit 0 ||  [[ ! -e "/var/www/composer.lock" ]] && echo "File /var/www/composer.lock not present, exiting." && exit 0 || /usr/local/bin/composer install'
-
   db:
     # mysql:8.0.11 keeps restarting.
     image: mysql:5.7.26

--- a/docker/docker-compose.ddev.yml
+++ b/docker/docker-compose.ddev.yml
@@ -51,6 +51,7 @@ services:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
       - webroot-sync-core:/var/www:nocopy
+      - ./${APP_ROOT}/web/sites/default/files:/var/www/web/sites/default/files:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -71,6 +72,7 @@ services:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
       - webroot-sync-core:/var/www:nocopy
+      - ./${APP_ROOT}/web/sites/default/files:/var/www/web/sites/default/files:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -153,6 +155,7 @@ services:
     container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - webroot-sync-core:/var/www:nocopy
+      - ./${APP_ROOT}/web/sites/default/files:/var/www/web/sites/default/files:delegated
       - nodemodules:/var/www/web/themes/custom/MYTHEME/node_modules
     # In case of several env files later declared variable
     # values override earlier ones

--- a/docker/docker-compose.ddev.yml
+++ b/docker/docker-compose.ddev.yml
@@ -79,24 +79,6 @@ services:
     restart: on-failure
     working_dir: /var/www
 
-  composer:
-    # Runs `composer install` during startup.
-    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
-    container_name: "${PROJECT_NAME}_composer"
-    volumes:
-      # This share gets writes from within the container by Composer.
-      # :nocopy must be used with docker-sync
-      # See bottom of this file, and ./docker-sync.yml
-      - webroot-sync-core:/var/www:nocopy
-    # In case of several env files later declared variable
-    # values override earlier ones
-    env_file:
-      - .env
-      - .env.local
-    restart: on-failure
-    working_dir: /var/www
-    command: sh -c '[[ "$CONTAINER_COMPOSER_START" -ne "1" ]] && echo "Container 'composer' disabled." && exit 0 ||  [[ ! -e "/var/www/composer.lock" ]] && echo "File /var/www/composer.lock not present, exiting." && exit 0 || /usr/local/bin/composer install'
-
   db:
     # mysql:8.0.11 keeps restarting.
     image: mysql:5.7.26

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -84,21 +84,6 @@ services:
     restart: on-failure
     working_dir: /var/www
 
-  composer:
-    # Runs `composer install` during startup.
-    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
-    container_name: "${PROJECT_NAME}_composer"
-    volumes:
-      - webroot-nfs-app:/var/www
-    # In case of several env files later declared variable
-    # values override earlier ones
-    env_file:
-      - .env
-      - .env.local
-    restart: on-failure
-    working_dir: /var/www
-    command: sh -c '[[ "$CONTAINER_COMPOSER_START" -ne "1" ]] && echo "Container 'composer' disabled." && exit 0 ||  [[ ! -e "/var/www/composer.lock" ]] && echo "File /var/www/composer.lock not present, exiting." && exit 0 || /usr/local/bin/composer install'
-
   db:
     # mysql:8.0.11 keeps restarting.
     image: mysql:5.7.26

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -83,26 +83,6 @@ services:
     restart: on-failure
     working_dir: /var/www
 
-  composer:
-    # Runs `composer install` during startup.
-    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
-    container_name: "${PROJECT_NAME}_composer"
-    volumes:
-      # This share gets writes from within the container by Composer.
-      # :nocopy must be used with docker-sync
-      # See bottom of this file, and ./docker-sync.yml
-      - webroot-sync-core:/var/www:nocopy
-      # Composer may need patches from this folder, too.
-      - webroot-sync-src-patches:/var/www/web/modules/local_patches:nocopy
-    # In case of several env files later declared variable
-    # values override earlier ones
-    env_file:
-      - .env
-      - .env.local
-    restart: on-failure
-    working_dir: /var/www
-    command: sh -c '[[ "$CONTAINER_COMPOSER_START" -ne "1" ]] && echo "Container 'composer' disabled." && exit 0 ||  [[ ! -e "/var/www/composer.lock" ]] && echo "File /var/www/composer.lock not present, exiting." && exit 0 || /usr/local/bin/composer install'
-
   db:
     # mysql:8.0.11 keeps restarting.
     image: mysql:5.7.26

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -50,6 +50,7 @@ services:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
       - webroot-sync-core:/var/www:nocopy
+      - ./${APP_ROOT}/web/sites/default/files:/var/www/web/sites/default/files:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -75,6 +76,7 @@ services:
       - webroot-sync-src-patches:/var/www/web/modules/local_patches:nocopy
       - webroot-sync-src-themes:/var/www/web/themes/custom:nocopy
       - webroot-sync-core:/var/www:nocopy
+      - ./${APP_ROOT}/web/sites/default/files:/var/www/web/sites/default/files:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -157,6 +159,7 @@ services:
     container_name: "${PROJECT_NAME}_nodejs_MYTHEME"
     volumes:
       - webroot-sync-core:/var/www:nocopy
+      - ./${APP_ROOT}/web/sites/default/files:/var/www/web/sites/default/files:delegated
       - nodemodules:/var/www/web/themes/custom/MYTHEME/node_modules
     # In case of several env files later declared variable
     # values override earlier ones

--- a/docker/docker-sync.common.yml
+++ b/docker/docker-sync.common.yml
@@ -18,16 +18,13 @@ syncs:
     # NOTE: run `docker-sync[-stack] clean` after any change in src
     src: './${APP_ROOT}/'
     host_disk_mount_mode: 'cached' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
-    sync_args:
-      - "-ignore='Path ld.sh'"    # no need to send our own OSX -side helper tools
-      - "-ignore='Path ld'"       # no need to send our own OSX -side helper tools
-      - "-ignore='Path .editorconfig'"  # no need to send PHPStorm config to container
-      - "-ignore='Path .idea'"          # no need to send PHPStorm config to container
-      - "-ignore='Path .git'"           # ignore the main .git repo
-      - "-ignore='BelowPath .git'"      # also ignore .git repos in subfolders such as in composer vendor dirs
-      - "-ignore='BelowPath node_modules'" # remove this if you need code completion
-      - "-ignore='Path node_modules/*'" # remove this if you need code completion
-#     - "-ignore='Path vendor/*'"     # we could ignore the composer vendor folder, but then you won't have code completion in your IDE
+    # sync_excludes seem to be relative to src-location inside container.
+    sync_excludes_type: 'BelowPath'
+    sync_excludes: [
+      '.git',
+      'web/themes/*/node_modules',
+      'web/themes/*/*/node_modules',
+      'web/sites/*/files']
     # enable terminal_notifier. On every sync sends a Terminal Notification regarding files being synced. ( Mac Only ).
     # good thing in case you are developing and want to know exactly when your changes took effect.
     # be aware in case of unison this only gives you a notification on the initial sync, not the syncs after changes.

--- a/docker/docker-sync.skeleton.yml
+++ b/docker/docker-sync.skeleton.yml
@@ -18,12 +18,13 @@ syncs:
     # NOTE: run `docker-sync[-stack] clean` after any change in src
     src: './${APP_ROOT}/'
     host_disk_mount_mode: 'cached' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
-    sync_args:
-      - "-ignore='Path .editorconfig'"  # no need to send PHPStorm config to container
-      - "-ignore='BelowPath .git'"      # also ignore .git repos in subfolders such as in composer vendor dirs
-      - "-ignore='BelowPath node_modules'" # remove this if you need code completion
-      - "-ignore='Path node_modules/*'" # remove this if you need code completion
-      # - "-ignore='Path vendor/*'"     # we could ignore the composer vendor folder, but then you won't have code completion in your IDE
+    sync_excludes_type: 'BelowPath'
+    # sync_excludes seem to be relative to src-location inside container.
+    sync_excludes: [
+      '.git',
+      'web/themes/*/node_modules',
+      'web/themes/*/*/node_modules',
+      'web/sites/*/files']
     # enable terminal_notifier. On every sync sends a Terminal Notification regarding files being synced. ( Mac Only ).
     # good thing in case you are developing and want to know exactly when your changes took effect.
     # be aware in case of unison this only gives you a notification on the initial sync, not the syncs after changes.
@@ -39,9 +40,6 @@ syncs:
     sync_strategy: 'native_osx'
     src: './src/modules/'
     host_disk_mount_mode: 'cached' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
-    sync_args:
-      - "-ignore='BelowPath .git'"      # also ignore .git repos in subfolders such as in composer vendor dirs
-      - "-ignore='BelowPath node_modules'" # remove this if you need code completion
     notify_terminal: true
 
   webroot-sync-src-patches:
@@ -54,8 +52,10 @@ syncs:
     sync_strategy: 'native_osx'
     src: './src/themes/'
     host_disk_mount_mode: 'cached' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
-    sync_args:
-      - "-ignore='BelowPath .git'"      # also ignore .git repos in subfolders such as in composer vendor dirs
-      - "-ignore='BelowPath node_modules'" # remove this if you need code completion
-      - "-ignore='Path node_modules/*'" # remove this if you need code completion
+    sync_excludes_type: 'BelowPath'
+    sync_excludes: [
+      '.git',
+      'web/themes/*/node_modules',
+      'web/themes/*/*/node_modules',
+      'web/sites/*/files']
     notify_terminal: true

--- a/docker/scripts/ld.command.configure-network-down.sh
+++ b/docker/scripts/ld.command.configure-network-down.sh
@@ -11,8 +11,8 @@ function ld_command_configure-network-down_exec() {
     if [ "$LOCAL_IP" != "127.0.0.1" ]; then
         IP_ALIAS_SET=$(ifconfig lo0 | grep -c $LOCAL_IP)
         if ((  "$IP_ALIAS_SET" > "0" )); then
-            echo -e "${Yellow}Removing an IP alias may require your password. Your password is not stored anywhere by local-docker.${Color_Off}"
-            echo -e "${Yellow}Removing an IP alias from your loopback network interface.${Color_Off}"
+            [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO: ${Yellow}Removing an IP alias from your loopback network interface.${Color_Off}"
+            [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Yellow}Removing an IP alias may require your password. Your password is not stored anywhere by local-docker.${Color_Off}"
             sudo ifconfig lo0 delete $LOCAL_IP
         fi
     fi

--- a/docker/scripts/ld.command.configure-network.sh
+++ b/docker/scripts/ld.command.configure-network.sh
@@ -10,7 +10,7 @@ function ld_command_configure-network_exec() {
     SUDO_REQUESTED=
 
     if [ "$LOCAL_IP" == "127.0.0.1" ]; then
-        echo -e "${Yellow}Project is using IP address 127.0.0.1, so IP alias is not needed.${Color_Off}"
+        [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Yellow}Project is using IP address 127.0.0.1, so IP alias is not needed.${Color_Off}"
     else
         IP_ALIAS_SET=$(ifconfig lo0 | grep -c $LOCAL_IP)
         if [  "$IP_ALIAS_SET" == "0" ]; then
@@ -20,7 +20,7 @@ function ld_command_configure-network_exec() {
             SUDO_REQUESTED=1
             sudo ifconfig lo0 alias $LOCAL_IP
         else
-            echo -e "${Green}IP alias $LOCAL_IP is already set.${Color_Off}"
+            [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BGreen}INFO: ${Green}IP alias ${BGreen}${LOCAL_IP}${Green} is already set.${Color_Off}"
         fi
     fi
 
@@ -34,9 +34,11 @@ function ld_command_configure-network_exec() {
             # - remove the line(s) starting with a $ (ie the like with nothing but "${LOCAL_DOMAIN}" in it),
             # - add a dot and the actual domain (not the variable itself) after each of the subdomains
             SUBDOMAINS=$(egrep 'traefik\.[a-z]*\.routers..*\.rule\=Host\(' docker-compose.yml | grep -o '[a-z0-9\.]*\${LOCAL_DOMAIN\}'  | cut -d'.' -f1 | grep -v '^\$' | xargs -I % echo %.${LOCAL_DOMAIN} | xargs)
-            echo -e "${Yellow}Adding domain $LOCAL_DOMAIN with subdomains to your hosts file to poin to $LOCAL_IP.${Color_Off}"
-            echo -e "${BYellow}NOTE: This DNS record is not removed automatically.${Color_Off}"
+            [ "$LD_VERBOSE" -ge "1" ] && echo -e "${BYellow}INFO: ${Yellow}Adding domain ${BYellow}${LOCAL_DOMAIN}${Yellow} to your hosts file with IP address ${BYellow}${LOCAL_IP}${Yellow}.${Color_Off}"
+            [ "$LD_VERBOSE" -ge "1" ] && echo -e "${BYellow}INFO: ${Yellow}Registered subdomains: ${BYellow}${SUBDOMAINS}${Yellow}${Yellow}.${Color_Off}"
+            [ "$LD_VERBOSE" -ge "1" ] && echo -e "${BYellow}NOTE: ${Yellow}This DNS record is not removed automatically.${Color_Off}"
             if [ -z "$SUDO_REQUESTED" ]; then
+                echo
                 echo -e "${Yellow}Configuring networking may require your password. Your password is not stored anywhere by local-docker.${Color_Off}"
                 echo
             fi
@@ -46,7 +48,7 @@ function ld_command_configure-network_exec() {
             sudo bash -c "echo '###  Project folder: $CWD' >> /etc/hosts"
             sudo bash -c "echo '$LOCAL_IP      $LOCAL_DOMAIN $SUBDOMAINS' >> /etc/hosts"
         else
-            echo -e "${Green}Domain $LOCAL_DOMAIN is already configured.${Color_Off}"
+            [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BGreen}INFO: ${Green}Domain ${BGreen}${LOCAL_DOMAIN}${Green} is already configured.${Color_Off}"
         fi
     fi
 }

--- a/docker/scripts/ld.command.drupal-structure-fix.sh
+++ b/docker/scripts/ld.command.drupal-structure-fix.sh
@@ -13,7 +13,7 @@ function ld_command_drupal-structure-fix_exec() {
       echo -e "${Red}ERROR: PHP container ('${CONTAINER_PHP:-php}')is not up.${Color_Off}"
       return 2
     fi
-    echo "Creating some folders to project below /var/www"
+    [ "$LD_VERBOSE" -ge "1" ] && echo -e "${Yellow}Creating some folders and setting file perms to project below ${BYellow}${APP_ROOT}${Yellow}.${Color_Off}"
     docker-compose -f $DOCKER_COMPOSE_FILE exec ${CONTAINER_PHP:-php} bash -c '[[ ! -d "config/sync" ]] &&  mkdir -vp config/sync'
     docker-compose -f $DOCKER_COMPOSE_FILE exec ${CONTAINER_PHP:-php} bash -c '[[ ! -d "web/sites/default/files" ]] &&  mkdir -vp web/sites/default/files'
     docker-compose -f $DOCKER_COMPOSE_FILE exec ${CONTAINER_PHP:-php} bash -c '[[ ! -w "web/sites/default/files" ]] &&  chmod -r 0777 web/sites/default/files'

--- a/docker/scripts/ld.command.rename-volumes.sh
+++ b/docker/scripts/ld.command.rename-volumes.sh
@@ -12,7 +12,6 @@ function ld_command_rename-volumes_exec() {
         if [[ -z "$VOL_BASE_NAME" ]] || [ ! -z "$VOL_BASE_NAME_DEFAULT_FAILED" ]; then
             read -p "Container volume base name ['$VOL_BASE_NAME']: " ANSWER
         else
-            echo -e "Using default value: ${VOL_BASE_NAME}"
             ANSWER=${VOL_BASE_NAME}
         fi
         if [ -z "$ANSWER" ]; then
@@ -33,10 +32,11 @@ function ld_command_rename-volumes_exec() {
         [ "$LD_VERBOSE" -ge "1" ] && echo 'Turning off docker-sync (clean), please wait...'
         docker-sync clean
     fi
+
     define_configuration_value VOL_BASE_NAME $VOL_BASE_NAME
     import_config
 
-    echo "Renaming volumes to '$VOL_BASE_NAME' for docker-sync, please wait..."
+    [ "$LD_VERBOSE" -ge "2" ] && echo && echo -e "${BYellow}INFO: ${Yellow}Docker-sync volume's base name: ${BYellow}${VOL_BASE_NAME}${Yellow}.${Color_Off}"
     replace_in_file "s/webroot-sync/${VOL_BASE_NAME}-sync/g" $DOCKERSYNC_FILE
     replace_in_file "s/webroot-sync/${VOL_BASE_NAME}-sync/g" $DOCKER_COMPOSE_FILE
     replace_in_file "s/webroot-nfs/${VOL_BASE_NAME}-nfs/g" $DOCKER_COMPOSE_FILE


### PR DESCRIPTION
Fixes #127 

Moves codebase building into init-time-only -container (composer), with no other volumes than slowish :cached mount to allow composer to start with an empty root folder. 

Removes composer -container form all the development stacks (docker-compose templates). 

Makes ./ld init more robust, respecting verbosity, too.

With this PR files touched inside  `web/sites/*/files` folder are not *synced* but transferred via the regular mount. This should speed up the start of each project tremendously, since the gigabytes of files inside the files -folder are not *synced* and need no comparing by docker-sync. 

This will, however, slow reading of some PHP files, namely compiled twig files (`files/php/twig/*`), but compared to the saved time during boot up it should not be a big issue.