### PR TITLE
Fix nodejs container's test ('[') commands to work on non-bash shells

### DIFF
--- a/docker/docker-compose.cached.yml
+++ b/docker/docker-compose.cached.yml
@@ -163,7 +163,7 @@ services:
       - .env.local
     restart: on-failure
     working_dir: /var/www/web/themes/custom/MYTHEME/
-    command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+    command: sh -c '[ "$CONTAINER_NODEJS_START" -ne "1" ] && echo "Nodejs container disabled." && exit 0 || [ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:
   db_data: {}

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -163,7 +163,7 @@ services:
       - .env.local
     restart: on-failure
     working_dir: /var/www/web/themes/custom/MYTHEME/
-    command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+    command: sh -c '[ "$CONTAINER_NODEJS_START" -ne "1" ] && echo "Nodejs container disabled." && exit 0 || [ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:
   webroot-sync-core:

--- a/docker/docker-compose.ddev.yml
+++ b/docker/docker-compose.ddev.yml
@@ -164,7 +164,7 @@ services:
       - .env.local
     restart: on-failure
     working_dir: /var/www/web/themes/custom/MYTHEME/
-    command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+    command: sh -c '[ "$CONTAINER_NODEJS_START" -ne "1" ] && echo "Nodejs container disabled." && exit 0 || [ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:
   webroot-sync-core:

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -165,7 +165,7 @@ services:
       - .env.local
     restart: on-failure
     working_dir: /var/www/web/themes/custom/MYTHEME/
-    command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+    command: sh -c '[ "$CONTAINER_NODEJS_START" -ne "1" ] && echo "Nodejs container disabled." && exit 0 || [ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:
   webroot-nfs-app:

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -168,7 +168,7 @@ services:
       - .env.local
     restart: on-failure
     working_dir: /var/www/web/themes/custom/MYTHEME/
-    command: sh -c '[[ "$CONTAINER_NODEJS_START" -ne "1" ]] && echo "Nodejs container disabled." && exit 0 || [[ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ]] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
+    command: sh -c '[ "$CONTAINER_NODEJS_START" -ne "1" ] && echo "Nodejs container disabled." && exit 0 || [ ! -e "/var/www/web/themes/custom/MYTHEME/gulpfile.js" ] && exit 0 || npm install --global gulp-cli && npm install && npm install bootstrap-sass && gulp watch'
 
 volumes:
   webroot-sync-core:


### PR DESCRIPTION
The '[[' is a bashism and never worked when invoking 'sh -c' on the
nodejs container. That is why the CONTAINER_NODEJS_START environment
variable never seemed to have any effect.

Another issue that I can immediately think of is that at least it should be documented that the default setup runs `npm install bootstrap-sass` which may very well not be what we want, at least not in Exovify use. I have not touched that here (yet) though.

