### PR TITLE
Speed up local bootup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,12 +42,15 @@ CONTAINER_NGINX=nginx
 # Set value to 1 to use nodejs (checked before the command is run)
 CONTAINER_NODEJS_START=0
 
-
-
 # Exposed container ports.
 CONTAINER_PORT_WEB=80
 CONTAINER_PORT_DB=3306
 CONTAINER_PORT_VARNISH=8017
+
+# Should match PHP container's www-data -user (from php:7.3-fpm-alpine et.al.).
+# This is used solely by docker-sync.
+DOCKER_SYNC_UID=82
+DOCKER_SYNC_GID=82
 
 
 #################################

--- a/docker/docker-sync.common.yml
+++ b/docker/docker-sync.common.yml
@@ -25,6 +25,18 @@ syncs:
       'web/themes/*/node_modules',
       'web/themes/*/*/node_modules',
       'web/sites/*/files']
+
+    sync_userid: '${DOCKER_SYNC_UID}'
+    sync_groupid: '${DOCKER_SYNC_GID}'
+
+    # monit can be used to monitor the health of unison in the native_osx strategy and can restart unison if it detects a problem
+    # optional: use this to switch monit monitoring on
+    monit_enable: true
+    # optional: use this to change how many seconds between each monit check (cycle)
+    monit_interval: 5
+    # optional: use this to change how many consecutive times high cpu usage must be observed before unison is restarted
+    monit_high_cpu_cycles: 2
+
     # enable terminal_notifier. On every sync sends a Terminal Notification regarding files being synced. ( Mac Only ).
     # good thing in case you are developing and want to know exactly when your changes took effect.
     # be aware in case of unison this only gives you a notification on the initial sync, not the syncs after changes.

--- a/docker/docker-sync.skeleton.yml
+++ b/docker/docker-sync.skeleton.yml
@@ -25,6 +25,18 @@ syncs:
       'web/themes/*/node_modules',
       'web/themes/*/*/node_modules',
       'web/sites/*/files']
+
+    sync_userid: '${DOCKER_SYNC_UID}'
+    sync_groupid: '${DOCKER_SYNC_GID}'
+
+    # monit can be used to monitor the health of unison in the native_osx strategy and can restart unison if it detects a problem
+    # optional: use this to switch monit monitoring on
+    monit_enable: true
+    # optional: use this to change how many seconds between each monit check (cycle)
+    monit_interval: 5
+    # optional: use this to change how many consecutive times high cpu usage must be observed before unison is restarted
+    monit_high_cpu_cycles: 2
+
     # enable terminal_notifier. On every sync sends a Terminal Notification regarding files being synced. ( Mac Only ).
     # good thing in case you are developing and want to know exactly when your changes took effect.
     # be aware in case of unison this only gives you a notification on the initial sync, not the syncs after changes.
@@ -34,18 +46,33 @@ syncs:
     sync_strategy: 'native_osx'
     src: './src/config/'
     host_disk_mount_mode: 'cached' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
+    sync_userid: '${DOCKER_SYNC_UID}'
+    sync_groupid: '${DOCKER_SYNC_GID}'
+    monit_enable: true
+    monit_interval: 5
+    monit_high_cpu_cycles: 2
     notify_terminal: true
 
   webroot-sync-src-modules:
     sync_strategy: 'native_osx'
     src: './src/modules/'
     host_disk_mount_mode: 'cached' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
+    sync_userid: '${DOCKER_SYNC_UID}'
+    sync_groupid: '${DOCKER_SYNC_GID}'
+    monit_enable: true
+    monit_interval: 5
+    monit_high_cpu_cycles: 2
     notify_terminal: true
 
   webroot-sync-src-patches:
     sync_strategy: 'native_osx'
     src: './src/local_patches/'
     host_disk_mount_mode: 'cached' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
+    sync_userid: '${DOCKER_SYNC_UID}'
+    sync_groupid: '${DOCKER_SYNC_GID}'
+    monit_enable: true
+    monit_interval: 5
+    monit_high_cpu_cycles: 2
     notify_terminal: true
 
   webroot-sync-src-themes:
@@ -58,4 +85,9 @@ syncs:
       'web/themes/*/node_modules',
       'web/themes/*/*/node_modules',
       'web/sites/*/files']
+    sync_userid: '${DOCKER_SYNC_UID}'
+    sync_groupid: '${DOCKER_SYNC_GID}'
+    monit_enable: true
+    monit_interval: 5
+    monit_high_cpu_cycles: 2
     notify_terminal: true

--- a/docker/scripts/ld.command.drupal-files-folder-perms.sh
+++ b/docker/scripts/ld.command.drupal-files-folder-perms.sh
@@ -13,9 +13,14 @@ function ld_command_drupal-files-folder-perms_exec() {
         echo -e "${Red}ERROR: PHP container ('${CONTAINER_PHP:-php}')is not up.${Color_Off}"
         return 2
     fi
-    # Can't figure out how to print msg. with quotes so that it also
-    # works as a command string.
-    COMM="docker-compose -f $DOCKER_COMPOSE_FILE exec ${CONTAINER_PHP:-php} bash -c 'chown -R www-data:root /var/www/web/sites'"
+
+    # Set folder perms, only, for speed.
+    COMM="docker-compose -f $DOCKER_COMPOSE_FILE exec ${CONTAINER_PHP:-php} bash -c 'find /var/www/web/sites -type d -exec chown -R www-data {}'"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
+    docker-compose -f $DOCKER_COMPOSE_FILE exec ${CONTAINER_PHP:-php} bash -c "chown -R www-data:root /var/www/web/sites"
+
+    # Set topmost file perms, only, for speed.
+    COMM="docker-compose -f $DOCKER_COMPOSE_FILE exec ${CONTAINER_PHP:-php} bash -c 'find web/sites/ -maxdepth 2 -type f -exec chown -R www-data {}'"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
     docker-compose -f $DOCKER_COMPOSE_FILE exec ${CONTAINER_PHP:-php} bash -c "chown -R www-data:root /var/www/web/sites"
 }


### PR DESCRIPTION
Make the bootup of local faster by chown'ing less files: Map the main sync folders with www-data's UID, and do the drupal-files-folder-fix faster by skipping _files_ - we really rarely need to remove them anyway (if ever). Folder ownership inside Drupal's `sites/XX/files` is probably enough.