### PR TITLE
Write xdebug status variables on toggle to local env file

### DIFF
--- a/docker/scripts/ld.command.xdebug.sh
+++ b/docker/scripts/ld.command.xdebug.sh
@@ -4,9 +4,11 @@
 # This file contains stop -command for local-docker script ld.sh.
 
 function ld_command_xdebug_exec() {
+    # NOTE we push these values to developer's local ENV file .env.local to
+    # avoid repeated changes known by Git in the project level file.
     case "$1" in
-        '1'|'on') define_configuration_value PHP_XDEBUG_REMOTE_ENABLE 1; sleep 1; docker-compose -f $DOCKER_COMPOSE_FILE up -d php && $SCRIPT_NAME xdebug;;
-        '0'|'off') define_configuration_value PHP_XDEBUG_REMOTE_ENABLE 0; docker-compose -f $DOCKER_COMPOSE_FILE up -d php && $SCRIPT_NAME xdebug;;
+        '1'|'on') define_configuration_value PHP_XDEBUG_REMOTE_ENABLE 1 .env.local; sleep 1; docker-compose -f $DOCKER_COMPOSE_FILE up -d php && $SCRIPT_NAME xdebug;;
+        '0'|'off') define_configuration_value PHP_XDEBUG_REMOTE_ENABLE 0 .env.local; docker-compose -f $DOCKER_COMPOSE_FILE up -d php && $SCRIPT_NAME xdebug;;
         *) docker-compose -f $DOCKER_COMPOSE_FILE exec php bash -c 'echo -n "Xdebug is: "; php -i | grep xdebug.remote_enable |tr -s " => " "|" | cut -d "|" -f2';;
     esac
 

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -174,7 +174,7 @@ function ensure_folders_present() {
 function define_configuration_value() {
     NAME=$1
     VAL=$2
-    FILE="./.env"
+    FILE=${3:-./.env}
 
     if [ ! -e "$FILE" ]; then
         echo -e "${Red}ERROR: File $FILE not present while trying to store a value into it.${Color_Off}";


### PR DESCRIPTION
Avoid writing Xdebug toggling values to .env to avoid unnecessary "dirty" state in project environment file.

Rather, allow variable value change to be targeted to .env.local. 

Note: this measn that once the value is present in the .env.local file, it WILL override any values present in the ./.env. Any ideas how to notify user about that are welcome.