### PR TITLE
Add https to local

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Place this inside your `sites/XXX/settings.php` file to fix the issue:
 	  // Do NOT do this in publicly accessbile site.
 	  $settings['reverse_proxy_addresses'] = [@$_SERVER['REMOTE_ADDR']];
 	  // See https://symfony.com/doc/current/deployment/proxies.html.
-	  $settings['reverse_proxy_trusted_headers'] = \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_ALL
+	  $settings['reverse_proxy_trusted_headers'] = \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_ALL;
 	}
 
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Place this inside your `sites/XXX/settings.php` file to fix the issue:
      */
 
     // Drupal 7 configuration.
-    if (explode('.', VERSION)[0] == 7) {
+    if (defined('VERSION') && explode('.', VERSION)[0] == 7) {
       $conf['reverse_proxy'] = TRUE;
       // Do NOT do this in publicly accessbile site.      $conf['reverse_proxy_addresses'] = [@$_SERVER['REMOTE_ADDR']];
 

--- a/README.md
+++ b/README.md
@@ -178,15 +178,15 @@ and by default credentials `drupal`/`drupal` with database named
 `drupal` (simple!). Example for Drupal 8:
 
     $databases['default']['default'] = [
-        'database' => 'drupal',
-        'username' => 'drupal',
-        'password' => 'drupal',
-        'prefix' => '',
-        'host' => 'db',   // <== IMPORTANT!
-        'port' => '3306',
-        'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-        'driver' => 'mysql',
-      ];
+      'database' => 'drupal',
+      'username' => 'drupal',
+      'password' => 'drupal',
+      'prefix' => '',
+      'host' => 'db',   // <== IMPORTANT!
+      'port' => '3306',
+      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+      'driver' => 'mysql',
+     ];
 
 However, editing `settings.php` manually for database connection is
 usually necessary only if you are applying `local-docker` on top of an

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ subdomains:
 
 During the initial project initialisation local-docker generates self-signed SSL/TLS cerificates for your local development needs. Certificate is created for `*.example.local` -domain, which means it covers all auto-generated subdomains you have.
 
-If you wish to have automatic HTTP -> HTTPS redirection for you local check your `docker-compose.yml` file and comment out some lines below `label` -key (under `nginx` or any other service).
+If you wish to have automatic HTTP -> HTTPS redirection for you local check your `docker-compose.yml` file and comment out some lines below `label` key (under `nginx` or any other service).
 
 You can also have several certificates for multiple domains. Place generated certificates inside `docker/certs` folder and adjust `docker/certs/certs.yml` file.
 

--- a/README.md
+++ b/README.md
@@ -177,8 +177,7 @@ done via your site's `settings.php` file. Where Skeleton may use
 and by default credentials `drupal`/`drupal` with database named
 `drupal` (simple!). Example for Drupal 8:
 
-    <?php
-      $databases['default']['default'] = [
+    $databases['default']['default'] = [
         'database' => 'drupal',
         'username' => 'drupal',
         'password' => 'drupal',
@@ -199,39 +198,39 @@ Since Traefik acts as proxy and terminates encrypted connections, `nginx` won't 
 
 Place this inside your `sites/XXX/settings.php` file to fix the issue:
 
-	/**
-	 * Tell all Drupal sites that we're running behind an HTTPS proxy.
-	 *
-	 * @see https://www.drupal.org/node/425990
-	 */
-	
-	// Drupal 7 configuration.
-	if (explode('.', VERSION)[0] == 7) {
-	  $conf['reverse_proxy'] = TRUE;
-	  // Do NOT do this in publicly accessbile site.	  $conf['reverse_proxy_addresses'] = [@$_SERVER['REMOTE_ADDR']];
-	
-	  // Force the protocol provided by the proxy. This isn't always done
-	  // automatically in Drupal 7. Otherwise, you'll get mixed content warnings
-	  // and/or some assets will be blocked by the browser.
-	  if (php_sapi_name() != 'cli') {
-	
-	    if (isset($_SERVER['SITE_SUBDIR']) && isset($_SERVER['RAW_HOST'])) {
-	      // Handle subdirectory mode (e.g. example.com/site1).
-	      $base_url = $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://' . $_SERVER['RAW_HOST'] . '/' . $_SERVER['SITE_SUBDIR'];
-	    }
-	    else {
-	      $base_url = $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://' . $_SERVER['HTTP_X_FORWARDED_HOST'];
-	    }
-	  }
-	}
-	// Drupal 8 configuration.
-	else {
-	  $settings['reverse_proxy'] = TRUE;
-	  // Do NOT do this in publicly accessbile site.
-	  $settings['reverse_proxy_addresses'] = [@$_SERVER['REMOTE_ADDR']];
-	  // See https://symfony.com/doc/current/deployment/proxies.html.
-	  $settings['reverse_proxy_trusted_headers'] = \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_ALL;
-	}
+    /**
+     * Tell all Drupal sites that we're running behind an HTTPS proxy.
+     *
+     * @see https://www.drupal.org/node/425990
+     */
+
+    // Drupal 7 configuration.
+    if (explode('.', VERSION)[0] == 7) {
+      $conf['reverse_proxy'] = TRUE;
+      // Do NOT do this in publicly accessbile site.      $conf['reverse_proxy_addresses'] = [@$_SERVER['REMOTE_ADDR']];
+
+      // Force the protocol provided by the proxy. This isn't always done
+      // automatically in Drupal 7. Otherwise, you'll get mixed content warnings
+      // and/or some assets will be blocked by the browser.
+      if (php_sapi_name() != 'cli') {
+
+        if (isset($_SERVER['SITE_SUBDIR']) && isset($_SERVER['RAW_HOST'])) {
+          // Handle subdirectory mode (e.g. example.com/site1).
+          $base_url = $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://' . $_SERVER['RAW_HOST'] . '/' . $_SERVER['SITE_SUBDIR'];
+        }
+        else {
+          $base_url = $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://' . $_SERVER['HTTP_X_FORWARDED_HOST'];
+        }
+      }
+    }
+    // Drupal 8 configuration.
+    else {
+      $settings['reverse_proxy'] = TRUE;
+      // Do NOT do this in publicly accessbile site.
+      $settings['reverse_proxy_addresses'] = [@$_SERVER['REMOTE_ADDR']];
+      // See https://symfony.com/doc/current/deployment/proxies.html.
+      $settings['reverse_proxy_trusted_headers'] = \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_ALL;
+    }
 
 
 ### Daily usage

--- a/docker/docker-compose.cached.yml
+++ b/docker/docker-compose.cached.yml
@@ -12,14 +12,34 @@ services:
     image: "traefik:v2.0.0"
     container_name: "${PROJECT_NAME}_traefik"
     ports:
-      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB}:80"
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB:-80}:80"
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB_SSL:-443}:443"
     labels:
-      # Dashboard
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.service=api@internal"
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.entrypoints=web"
+      - "traefik.enable=true"
+      # DASHBOARD
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.entrypoints=web"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.service=api@internal"
+
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.entrypoints=websecure"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.service=api@internal"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.tls=true"
+
+      #  !!!! redirection HTTP to HTTPS - BEGIN !!!!
+      # This catches http request ONLY if there is no router which has a matching
+      # host -rule and attached to entrypoint "web".
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.rule=HostRegexp(`{any:.*}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.entrypoints=web"
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.middlewares=redirect-to-https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      #  !!!! redirection HTTP to HTTPS - END !!!!
+
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./docker/certs:/certs:delegated
+      - ./docker/certs/certs.yml:/etc/traefik/certs.yml:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -28,24 +48,47 @@ services:
     restart: on-failure
     command:
       # NOTE: entrypoints.XX.address MUST NOT contain IP, but only port.
-      - "--entrypoints.web.address=:${CONTAINER_PORT_WEB}"
+      - "--entrypoints.web.address=:${CONTAINER_PORT_WEB:-80}"
+      - "--entryPoints.web.forwardedHeaders.insecure"
+      - "--entrypoints.websecure.address=:${CONTAINER_PORT_WEB_SSL:-443}"
+      - "--entryPoints.websecure.forwardedHeaders.insecure"
       - --providers.docker
+      - --ping
       - --api
-      - --api.insecure=true
-      - --api.debug=true
+      - --api.dashboard
+      - --providers.file.filename=/etc/traefik/certs.yml
+      #- --log.level=DEBUG
 
   whoami:
     image: containous/whoami:v1.3.0
     container_name: "${PROJECT_NAME}_whoami"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-whoami.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-plain.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-https.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-https.tls=true"
+
     restart: on-failure
 
   nginx:
     build: ./docker/build/nginx
     container_name: "${PROJECT_NAME}_nginx"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--www-plain.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--www-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--www-https.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--www-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--www-https.tls=true"
+
     volumes:
       # :cached must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
@@ -115,7 +158,16 @@ services:
     image: solr:8.2.0
     container_name: "${PROJECT_NAME}_solr"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-solr.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--solr-plain.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--solr-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.tls=true"
+
     volumes:
       - solr_data:/var/solr
     # In case of several env files later declared variable
@@ -132,7 +184,16 @@ services:
     image: adminer:4.7.3
     container_name: "${PROJECT_NAME}_adminer"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-db-client.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-plain.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.tls=true"
+
     restart: on-failure
 
   # PHP container needs some Mailhog -configuration.
@@ -140,9 +201,18 @@ services:
     image: mailhog/mailhog:v1.0.0
     container_name: "${PROJECT_NAME}_mailhog"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-plain.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.tls=true"
       # https://docs.traefik.io/routing/providers/docker/#service-definition
       - "traefik.http.services.${PROJECT_NAME}--mailhog.loadbalancer.server.port=8025"
+
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -12,14 +12,34 @@ services:
     image: "traefik:v2.0.0"
     container_name: "${PROJECT_NAME}_traefik"
     ports:
-      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB}:80"
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB:-80}:80"
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB_SSL:-443}:443"
     labels:
-      # Dashboard
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.service=api@internal"
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.entrypoints=web"
+      - "traefik.enable=true"
+      # DASHBOARD
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.entrypoints=web"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.service=api@internal"
+
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.entrypoints=websecure"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.service=api@internal"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.tls=true"
+
+      #  !!!! redirection HTTP to HTTPS - BEGIN !!!!
+      # This catches http request ONLY if there is no router which has a matching
+      # host -rule and attached to entrypoint "web".
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.rule=HostRegexp(`{any:.*}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.entrypoints=web"
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.middlewares=redirect-to-https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      #  !!!! redirection HTTP to HTTPS - END !!!!
+
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./docker/certs:/certs:delegated
+      - ./docker/certs/certs.yml:/etc/traefik/certs.yml:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -28,24 +48,47 @@ services:
     restart: on-failure
     command:
       # NOTE: entrypoints.XX.address MUST NOT contain IP, but only port.
-      - "--entrypoints.web.address=:${CONTAINER_PORT_WEB}"
+      - "--entrypoints.web.address=:${CONTAINER_PORT_WEB:-80}"
+      - "--entryPoints.web.forwardedHeaders.insecure"
+      - "--entrypoints.websecure.address=:${CONTAINER_PORT_WEB_SSL:-443}"
+      - "--entryPoints.websecure.forwardedHeaders.insecure"
       - --providers.docker
+      - --ping
       - --api
-      - --api.insecure=true
-      - --api.debug=true
+      - --api.dashboard
+      - --providers.file.filename=/etc/traefik/certs.yml
+      #- --log.level=DEBUG
 
   whoami:
     image: containous/whoami:v1.3.0
     container_name: "${PROJECT_NAME}_whoami"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-whoami.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-plain.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-https.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-https.tls=true"
+
     restart: on-failure
 
   nginx:
     build: ./docker/build/nginx
     container_name: "${PROJECT_NAME}_nginx"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--www-plain.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--www-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--www-https.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--www-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--www-https.tls=true"
+
     volumes:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
@@ -115,7 +158,16 @@ services:
     image: solr:8.2.0
     container_name: "${PROJECT_NAME}_solr"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-solr.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--solr-plain.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--solr-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.tls=true"
+
     volumes:
       - solr_data:/var/solr
     # In case of several env files later declared variable
@@ -132,7 +184,16 @@ services:
     image: adminer:4.7.3
     container_name: "${PROJECT_NAME}_adminer"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-db-client.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-plain.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.tls=true"
+
     restart: on-failure
 
   # PHP container needs some Mailhog -configuration.
@@ -140,9 +201,18 @@ services:
     image: mailhog/mailhog:v1.0.0
     container_name: "${PROJECT_NAME}_mailhog"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-plain.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.tls=true"
       # https://docs.traefik.io/routing/providers/docker/#service-definition
       - "traefik.http.services.${PROJECT_NAME}--mailhog.loadbalancer.server.port=8025"
+
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the

--- a/docker/docker-compose.ddev.yml
+++ b/docker/docker-compose.ddev.yml
@@ -13,14 +13,34 @@ services:
     image: "traefik:v2.0.0"
     container_name: "${PROJECT_NAME}_traefik"
     ports:
-      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB}:80"
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB:-80}:80"
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB_SSL:-443}:443"
     labels:
-      # Dashboard
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.service=api@internal"
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.entrypoints=web"
+      - "traefik.enable=true"
+      # DASHBOARD
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.entrypoints=web"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.service=api@internal"
+
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.entrypoints=websecure"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.service=api@internal"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.tls=true"
+
+      #  !!!! redirection HTTP to HTTPS - BEGIN !!!!
+      # This catches http request ONLY if there is no router which has a matching
+      # host -rule and attached to entrypoint "web".
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.rule=HostRegexp(`{any:.*}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.entrypoints=web"
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.middlewares=redirect-to-https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      #  !!!! redirection HTTP to HTTPS - END !!!!
+
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./docker/certs:/certs:delegated
+      - ./docker/certs/certs.yml:/etc/traefik/certs.yml:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -29,24 +49,47 @@ services:
     restart: on-failure
     command:
       # NOTE: entrypoints.XX.address MUST NOT contain IP, but only port.
-      - "--entrypoints.web.address=:${CONTAINER_PORT_WEB}"
+      - "--entrypoints.web.address=:${CONTAINER_PORT_WEB:-80}"
+      - "--entryPoints.web.forwardedHeaders.insecure"
+      - "--entrypoints.websecure.address=:${CONTAINER_PORT_WEB_SSL:-443}"
+      - "--entryPoints.websecure.forwardedHeaders.insecure"
       - --providers.docker
+      - --ping
       - --api
-      - --api.insecure=true
-      - --api.debug=true
+      - --api.dashboard
+      - --providers.file.filename=/etc/traefik/certs.yml
+      #- --log.level=DEBUG
 
   whoami:
     image: containous/whoami:v1.3.0
     container_name: "${PROJECT_NAME}_whoami"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-whoami.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-plain.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-https.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-https.tls=true"
+
     restart: on-failure
 
   nginx:
     build: ./docker/build/nginx
     container_name: "${PROJECT_NAME}_nginx"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--www-plain.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--www-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--www-https.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--www-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--www-https.tls=true"
+
     volumes:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
@@ -116,7 +159,16 @@ services:
     image: solr:8.2.0
     container_name: "${PROJECT_NAME}_solr"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-solr.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--solr-plain.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--solr-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.tls=true"
+
     volumes:
       - solr_data:/var/solr
     # In case of several env files later declared variable
@@ -133,7 +185,16 @@ services:
     image: adminer:4.7.3
     container_name: "${PROJECT_NAME}_adminer"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-db-client.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-plain.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.tls=true"
+
     restart: on-failure
 
   # PHP container needs some Mailhog -configuration.
@@ -141,9 +202,18 @@ services:
     image: mailhog/mailhog:v1.0.0
     container_name: "${PROJECT_NAME}_mailhog"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-plain.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.tls=true"
       # https://docs.traefik.io/routing/providers/docker/#service-definition
       - "traefik.http.services.${PROJECT_NAME}--mailhog.loadbalancer.server.port=8025"
+
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -18,14 +18,34 @@ services:
     image: "traefik:v2.0.0"
     container_name: "${PROJECT_NAME}_traefik"
     ports:
-      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB}:80"
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB:-80}:80"
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB_SSL:-443}:443"
     labels:
-      # Dashboard
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.service=api@internal"
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.entrypoints=web"
+      - "traefik.enable=true"
+      # DASHBOARD
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.entrypoints=web"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.service=api@internal"
+
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.entrypoints=websecure"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.service=api@internal"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.tls=true"
+
+      #  !!!! redirection HTTP to HTTPS - BEGIN !!!!
+      # This catches http request ONLY if there is no router which has a matching
+      # host -rule and attached to entrypoint "web".
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.rule=HostRegexp(`{any:.*}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.entrypoints=web"
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.middlewares=redirect-to-https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      #  !!!! redirection HTTP to HTTPS - END !!!!
+
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./docker/certs:/certs:delegated
+      - ./docker/certs/certs.yml:/etc/traefik/certs.yml:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -34,24 +54,47 @@ services:
     restart: on-failure
     command:
       # NOTE: entrypoints.XX.address MUST NOT contain IP, but only port.
-      - "--entrypoints.web.address=:${CONTAINER_PORT_WEB}"
+      - "--entrypoints.web.address=:${CONTAINER_PORT_WEB:-80}"
+      - "--entryPoints.web.forwardedHeaders.insecure"
+      - "--entrypoints.websecure.address=:${CONTAINER_PORT_WEB_SSL:-443}"
+      - "--entryPoints.websecure.forwardedHeaders.insecure"
       - --providers.docker
+      - --ping
       - --api
-      - --api.insecure=true
-      - --api.debug=true
+      - --api.dashboard
+      - --providers.file.filename=/etc/traefik/certs.yml
+      #- --log.level=DEBUG
 
     whoami:
       image: containous/whoami:v1.3.0
       container_name: "${PROJECT_NAME}_whoami"
       labels:
-        - "traefik.http.routers.${PROJECT_NAME}--web-ui-whoami.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
-    restart: on-failure
+        # Comment out routers with entrypoint "web" to add http -> https redirect.
+        - "traefik.http.routers.${PROJECT_NAME}--whoami-plain.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+        - "traefik.http.routers.${PROJECT_NAME}--whoami-plain.entrypoints=web"
+
+        - "traefik.http.routers.${PROJECT_NAME}--whoami-https.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+        - "traefik.http.routers.${PROJECT_NAME}--whoami-https.entrypoints=websecure"
+        # This tells Traefik to terminate the SSL connection,
+        # @see https://docs.traefik.io/routing/routers/#tls
+        - "traefik.http.routers.${PROJECT_NAME}--whoami-https.tls=true"
+
+      restart: on-failure
 
     nginx:
       build: ./docker/build/nginx
       container_name: "${PROJECT_NAME}_nginx"
       labels:
-        - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+        # Comment out routers with entrypoint "web" to add http -> https redirect.
+        - "traefik.http.routers.${PROJECT_NAME}--www-plain.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+        - "traefik.http.routers.${PROJECT_NAME}--www-plain.entrypoints=web"
+
+        - "traefik.http.routers.${PROJECT_NAME}--www-https.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+        - "traefik.http.routers.${PROJECT_NAME}--www-https.entrypoints=websecure"
+        # This tells Traefik to terminate the SSL connection,
+        # @see https://docs.traefik.io/routing/routers/#tls
+        - "traefik.http.routers.${PROJECT_NAME}--www-https.tls=true"
+
       volumes:
         # :nocopy must be used with docker-sync
         # See bottom of this file, and ./docker-sync.yml
@@ -118,7 +161,16 @@ services:
     image: solr:8.2.0
     container_name: "${PROJECT_NAME}_solr"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-solr.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--solr-plain.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--solr-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.tls=true"
+
     volumes:
       - solr_data:/var/solr
     # In case of several env files later declared variable
@@ -135,7 +187,16 @@ services:
     image: adminer:4.7.3
     container_name: "${PROJECT_NAME}_adminer"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-db-client.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-plain.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.tls=true"
+
     restart: on-failure
 
   # PHP container needs some Mailhog -configuration.
@@ -143,9 +204,18 @@ services:
     image: mailhog/mailhog:v1.0.0
     container_name: "${PROJECT_NAME}_mailhog"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-plain.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.tls=true"
       # https://docs.traefik.io/routing/providers/docker/#service-definition
       - "traefik.http.services.${PROJECT_NAME}--mailhog.loadbalancer.server.port=8025"
+
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -12,14 +12,34 @@ services:
     image: "traefik:v2.0.0"
     container_name: "${PROJECT_NAME}_traefik"
     ports:
-      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB}:80"
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB:-80}:80"
+      - "${LOCAL_IP:-127.0.0.1}:${CONTAINER_PORT_WEB_SSL:-443}:443"
     labels:
-      # Dashboard
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.service=api@internal"
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-traefik.entrypoints=web"
+      - "traefik.enable=true"
+      # DASHBOARD
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.entrypoints=web"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-plain.service=api@internal"
+
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.rule=Host(`traefik.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.entrypoints=websecure"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.service=api@internal"
+      - "traefik.http.routers.${PROJECT_NAME}--traefik-https.tls=true"
+
+      #  !!!! redirection HTTP to HTTPS - BEGIN !!!!
+      # This catches http request ONLY if there is no router which has a matching
+      # host -rule and attached to entrypoint "web".
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.rule=HostRegexp(`{any:.*}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.entrypoints=web"
+      - "traefik.http.routers.${PROJECT_NAME}--http_catchall.middlewares=redirect-to-https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      #  !!!! redirection HTTP to HTTPS - END !!!!
+
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./docker/certs:/certs:delegated
+      - ./docker/certs/certs.yml:/etc/traefik/certs.yml:delegated
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -28,24 +48,47 @@ services:
     restart: on-failure
     command:
       # NOTE: entrypoints.XX.address MUST NOT contain IP, but only port.
-      - "--entrypoints.web.address=:${CONTAINER_PORT_WEB}"
+      - "--entrypoints.web.address=:${CONTAINER_PORT_WEB:-80}"
+      - "--entryPoints.web.forwardedHeaders.insecure"
+      - "--entrypoints.websecure.address=:${CONTAINER_PORT_WEB_SSL:-443}"
+      - "--entryPoints.websecure.forwardedHeaders.insecure"
       - --providers.docker
+      - --ping
       - --api
-      - --api.insecure=true
-      - --api.debug=true
+      - --api.dashboard
+      - --providers.file.filename=/etc/traefik/certs.yml
+      #- --log.level=DEBUG
 
   whoami:
     image: containous/whoami:v1.3.0
     container_name: "${PROJECT_NAME}_whoami"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-whoami.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-plain.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-https.rule=Host(`whoami.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--whoami-https.tls=true"
+
     restart: on-failure
 
   nginx:
     build: ./docker/build/nginx
     container_name: "${PROJECT_NAME}_nginx"
     labels:
-       - "traefik.http.routers.${PROJECT_NAME}--web-ui.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--www-plain.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--www-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--www-https.rule=Host(`${LOCAL_DOMAIN}`, `www.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--www-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--www-https.tls=true"
+
     volumes:
       # :nocopy must be used with docker-sync
       # See bottom of this file, and ./docker-sync.yml
@@ -120,7 +163,16 @@ services:
     image: solr:8.2.0
     container_name: "${PROJECT_NAME}_solr"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-solr.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--solr-plain.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--solr-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.rule=Host(`solr.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--solr-https.tls=true"
+
     volumes:
       - solr_data:/var/solr
     # In case of several env files later declared variable
@@ -137,7 +189,16 @@ services:
     image: adminer:4.7.3
     container_name: "${PROJECT_NAME}_adminer"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-db-client.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-plain.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.rule=Host(`adminer.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--adminer-https.tls=true"
+
     restart: on-failure
 
   # PHP container needs some Mailhog -configuration.
@@ -145,9 +206,18 @@ services:
     image: mailhog/mailhog:v1.0.0
     container_name: "${PROJECT_NAME}_mailhog"
     labels:
-      - "traefik.http.routers.${PROJECT_NAME}--web-ui-mail.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      # Comment out routers with entrypoint "web" to add http -> https redirect.
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-plain.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-plain.entrypoints=web"
+
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.rule=Host(`mailhog.${LOCAL_DOMAIN}`)"
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.entrypoints=websecure"
+      # This tells Traefik to terminate the SSL connection,
+      # @see https://docs.traefik.io/routing/routers/#tls
+      - "traefik.http.routers.${PROJECT_NAME}--mailhog-https.tls=true"
       # https://docs.traefik.io/routing/providers/docker/#service-definition
       - "traefik.http.services.${PROJECT_NAME}--mailhog.loadbalancer.server.port=8025"
+
     restart: on-failure
 
   # Replace MYTHEME with your theme name. If you have multiple the

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -231,6 +231,10 @@ function ld_command_init_exec() {
     fi
 
     echo
+    echo -e "${BBlack}== Generating SSL/TLS certificates ==${Color_Off}"
+    $SCRIPT_NAME tls-cert
+
+    echo
     echo -e "${BBlack}== Installing Drupal project ==${Color_Off}"
     echo "Please select which version of drupal you wish to have."
     echo "Alternatively you can install your codebase manually into $APP_ROOT."

--- a/docker/scripts/ld.command.tls-cert-check.sh
+++ b/docker/scripts/ld.command.tls-cert-check.sh
@@ -11,8 +11,10 @@ function ld_command_tls-cert-check_exec() {
     CERTFILEBASE_FULL="${CERT_FOLDER}/${CERTFILENAME}"
 
 
-    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Checking certificate in: ${CERTFILEBASE_FULL}.crt${Color_Off}"
-    openssl x509 -in ${CERTFILEBASE_FULL}.crt -noout -text
+    [ "$LD_VERBOSE" -ge "1" ] && echo -e "${BYellow}INFO:${Yellow} Checking certificate in: ${CERTFILEBASE_FULL}.crt${Color_Off}"
+    COMM="openssl x509 -in ${CERTFILEBASE_FULL}.crt -noout -text"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: ${COMM}${Color_Off}"
+    $COMM
 
 }
 

--- a/docker/scripts/ld.command.tls-cert-check.sh
+++ b/docker/scripts/ld.command.tls-cert-check.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# File
+#
+# This file contains tls-cert-check -command for local-docker script ld.sh.
+
+function ld_command_tls-cert-check_exec() {
+    CERT_FOLDER="./docker/certs"
+    mkdir -p ${CERT_FOLDER}
+
+    CERTFILENAME="${PROJECT_NAME}--self-signed"
+    CERTFILEBASE_FULL="${CERT_FOLDER}/${CERTFILENAME}"
+
+
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Checking certificate in: ${CERTFILEBASE_FULL}.crt${Color_Off}"
+    openssl x509 -in ${CERTFILEBASE_FULL}.crt -noout -text
+
+}
+
+function ld_command_tls-cert-check_help() {
+    echo "Check the local TLS certificate (HTTPS)."
+}
+
+
+function ld_command_tls-cert-check_extended_help() {
+    echo "Check the local TLS certificate (HTTPS)."
+    echo " "
+    echo "You can re-generate the certificate at any point."
+    echo "$ ./ld tls-cert"
+    echo " "
+}

--- a/docker/scripts/ld.command.tls-cert.sh
+++ b/docker/scripts/ld.command.tls-cert.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # File
 #
-# This file contains run-tests -command for local-docker script ld.sh.
+# This file contains tls-cert -command for local-docker script ld.sh.
 
 function ld_command_tls-cert_exec() {
     CERT_FOLDER="./docker/certs"

--- a/docker/scripts/ld.command.tls-cert.sh
+++ b/docker/scripts/ld.command.tls-cert.sh
@@ -67,14 +67,19 @@ function ld_command_tls-cert_exec() {
     $COMM
 
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Writing instructions for Traefik how to use our certs.${Color_Off}"
-    echo "tls:"                                             > ${CERTS_FILE}
-    echo "  stores:"                                        >> ${CERTS_FILE}
-    echo "    default:"                                     >> ${CERTS_FILE}
-    echo "        defaultCertificate:"                      >> ${CERTS_FILE}
-    echo "        - certFile: ${CERTFILENAME}.crt"         >> ${CERTS_FILE}
-    echo "          keyFile: ${CERTFILENAME}.key"          >> ${CERTS_FILE}
-    echo "#        - certFile: /path/to/other-domain.cert"  >> ${CERTS_FILE}
-    echo "#          keyFile: /path/to/other-domain.key"    >> ${CERTS_FILE}
+    echo "# https://docs.traefik.io/v2.0/https/tls/"            > ${CERTS_FILE}
+    echo "tls:"                                                 >> ${CERTS_FILE}
+    echo "  stores:"                                            >> ${CERTS_FILE}
+    echo "    default:"                                         >> ${CERTS_FILE}
+    echo "        defaultCertificate:"                          >> ${CERTS_FILE}
+    echo "          certFile: /certs/${CERTFILENAME}.crt"       >> ${CERTS_FILE}
+    echo "          keyFile: /certs/${CERTFILENAME}.key"        >> ${CERTS_FILE}
+    echo "#  certificates:"                                     >> ${CERTS_FILE}
+    echo "#  # tls.certificates is array"                       >> ${CERTS_FILE}
+    echo "#    - certFile: /path/to/other-domain.cert"          >> ${CERTS_FILE}
+    echo "#      keyFile: /path/to/other-domain.key"            >> ${CERTS_FILE}
+    echo "#    - certFile: /path/to/more-domain.cert"           >> ${CERTS_FILE}
+    echo "#      keyFile: /path/to/more-domain.key"             >> ${CERTS_FILE}
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} You may generate more certs manually, and then add the files to ./docker/certs/certs.yml file.${Color_Off}"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Traefik uses them if the domain matches, and generates a temporary cert if no matching cert file is found${Color_Off}"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} More info in local-docker README file.${Color_Off}"

--- a/docker/scripts/ld.command.tls-cert.sh
+++ b/docker/scripts/ld.command.tls-cert.sh
@@ -100,7 +100,7 @@ function ld_command_tls-cert_extended_help() {
     echo "(mounted volume)."
     echo " "
     echo "Certificate is a multidomain certificate: "
-    echo "    *.example.com"
+    echo "    *.${LOCAL_DOMAIN:-example.com}"
     echo " "
     echo "You can re-generate the files any time. Should you need more than one certificate"
     echo "you can rename existing files and generate new ones using command "

--- a/docker/scripts/ld.command.tls-cert.sh
+++ b/docker/scripts/ld.command.tls-cert.sh
@@ -110,6 +110,6 @@ function ld_command_tls-cert_extended_help() {
     echo "your project needs."
     echo " "
     echo "NOTE: By default Traefik configuration is set to handle also HTTPS requests, but "
-    echo "rediretion HTTP -> HTTPS (nginx, mailhog, solr, etc.) need docker-compose.yml file "
+    echo "redirection HTTP -> HTTPS (nginx, mailhog, solr, etc.) need docker-compose.yml file "
     echo "edits to work properly".
 }

--- a/docker/scripts/ld.command.tls-cert.sh
+++ b/docker/scripts/ld.command.tls-cert.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# File
+#
+# This file contains run-tests -command for local-docker script ld.sh.
+
+function ld_command_tls-cert_exec() {
+    CERT_FOLDER="./docker/certs"
+    mkdir -p ${CERT_FOLDER}
+
+    CERTFILENAME="${PROJECT_NAME}--self-signed"
+    CERTFILEBASE_FULL="${CERT_FOLDER}/${CERTFILENAME}"
+    CONF_FILE=${CERTFILEBASE_FULL}.conf
+    CONF_FILE_TMP=${CONF_FILE}.tmp
+    CERTS_FILE=${CERT_FOLDER}/certs.yml
+
+    # Create the local project cert confiuration (tmp file). Ideally it should
+    # not change so we create it only when it is not present.
+    # However, since we actually may have the file but need to create cert with
+    # some other configurations, create the file as temporary file first.
+    touch ${CONF_FILE_TMP}
+    echo "[req]"                                > ${CONF_FILE_TMP}
+    echo "default_bits       = 2048"            >> ${CONF_FILE_TMP}
+    echo "distinguished_name = dn"              >> ${CONF_FILE_TMP}
+    echo "prompt             = no"              >> ${CONF_FILE_TMP}
+    echo "[dn]"                                 >> ${CONF_FILE_TMP}
+    echo "C=FI"                                 >> ${CONF_FILE_TMP}
+    echo "ST=Helsinki"                          >> ${CONF_FILE_TMP}
+    echo "OU=LocalDocker"                       >> ${CONF_FILE_TMP}
+    echo "emailAddress=admin@${LOCAL_DOMAIN}"   >> ${CONF_FILE_TMP}
+    echo "CN=*.${LOCAL_DOMAIN}"                 >> ${CONF_FILE_TMP}
+    echo "[req_ext]"                            >> ${CONF_FILE_TMP}
+    echo "subjectAltName = @alt_names"          >> ${CONF_FILE_TMP}
+    echo "[alt_names]"                          >> ${CONF_FILE_TMP}
+    echo "DNS.0 = ${LOCAL_DOMAIN}"              >> ${CONF_FILE_TMP}
+    echo "DNS.1 = www.${LOCAL_DOMAIN}"          >> ${CONF_FILE_TMP}
+    echo "DNS.2 = traefik.${LOCAL_DOMAIN}"      >> ${CONF_FILE_TMP}
+    echo "DNS.3 = whoami.${LOCAL_DOMAIN}"       >> ${CONF_FILE_TMP}
+    echo "DNS.4 = solr.${LOCAL_DOMAIN}"         >> ${CONF_FILE_TMP}
+    echo "DNS.5 = adminer.${LOCAL_DOMAIN}"      >> ${CONF_FILE_TMP}
+    echo "DNS.6 = mailhog.${LOCAL_DOMAIN}"      >> ${CONF_FILE_TMP}
+
+    if [ ! -f "$CONF_FILE" ]; then
+        mv $CONF_FILE_TMP $CONF_FILE
+        [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Green}TLS Certificate configuration created: ${BGreen}${CONF_FILE}.${Color_Off}"
+    else
+        echo -e "${Red}ERROR: TLS certificate configuration exists, new config written to: ${BRed}${CONF_FILE_TMP}.${Color_Off}"
+        echo -e "${Red}Please investigate manually.${Color_Off}"
+        cd $CWD
+        exit 1
+    fi
+
+    # Heavily borrowed from https://github.com/abmruman/traefik-docker-compose/
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Generating random key...${Color_Off}"
+    openssl genrsa -out ${CERTFILEBASE_FULL}.key >/dev/null
+
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Generating CSR file...${Color_Off}"
+    openssl req -new -key ${CERTFILEBASE_FULL}.key -out ${CERTFILEBASE_FULL}.csr -config ${CONF_FILE}
+
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Generating TLS file (the HTTPS certificate) ...${Color_Off}"
+    openssl x509 -req -days 365 -in ${CERTFILEBASE_FULL}.csr -signkey ${CERTFILEBASE_FULL}.key -out ${CERTFILEBASE_FULL}.crt -extensions req_ext -extfile ${CERTFILEBASE_FULL}.conf
+
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Writing instructions for Traefik how to use our certs..${Color_Off}"
+    echo "tls:"                                             > ${CERTS_FILE}
+    echo "  stores:"                                        >> ${CERTS_FILE}
+    echo "    default:"                                     >> ${CERTS_FILE}
+    echo "        defaultCertificate:"                      >> ${CERTS_FILE}
+    echo "        - certFile: ${CERTFILENAME}.crt"         >> ${CERTS_FILE}
+    echo "          keyFile: ${CERTFILENAME}.key"          >> ${CERTS_FILE}
+    echo "#        - certFile: /path/to/other-domain.cert"  >> ${CERTS_FILE}
+    echo "#          keyFile: /path/to/other-domain.key"    >> ${CERTS_FILE}
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} You may generate more certs manually, and then add the files to ./docker/certs/certs.yml file..${Color_Off}"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Traefik uses them if the domain matches, and generates a temporary cert if no matching cert file is found${Color_Off}"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} More info in local-docker README file.${Color_Off}"
+
+}
+
+function ld_command_tls-cert_help() {
+    echo "Create local TLS certificate (HTTPS). Does not adjust your Traefik settings, so consult you docker-compose.yml file's traefik -servicde labels for required changes."
+}
+
+
+function ld_command_tls-cert_extended_help() {
+    echo "Create local TLS certificate (HTTPS)"
+    echo " "
+    echo "Certificates and the configuration are created during init -phase"
+    echo "prefixed with the project neme and stored in docker/certs -folder."
+    echo "Traefik learns about your HTTPS certificates via ./docker/certs/certs.yml -file"
+    echo "(mounted volume)."
+    echo " "
+    echo "Certificate is a multidomain certificate: "
+    echo "    *.example.com"
+    echo " "
+    echo "You can re-generate the files any time. Should you need more than one certificate"
+    echo "you can rename existing files and generate new ones using command "
+    echo "$ ./ld tls-cert"
+    echo " "
+    echo "Remember to update also file ./docker/certs/certs.yml to contain all the certificates"
+    echo "your project needs."
+    echo " "
+    echo "NOTE: By default Traefik configuration is set to handle also HTTPS requests, but "
+    echo "rediretion HTTP -> HTTPS (nginx, mailhog, solr, etc.) need docker-compose.yml file "
+    echo "edits to work properly".
+}

--- a/docker/scripts/ld.command.tls-cert.sh
+++ b/docker/scripts/ld.command.tls-cert.sh
@@ -51,15 +51,22 @@ function ld_command_tls-cert_exec() {
 
     # Heavily borrowed from https://github.com/abmruman/traefik-docker-compose/
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Generating random key...${Color_Off}"
-    openssl genrsa -out ${CERTFILEBASE_FULL}.key >/dev/null
+
+    COMM="openssl genrsa -out ${CERTFILEBASE_FULL}.key"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: ${COMM} >/dev/null${Color_Off}"
+    $COMM >/dev/null
 
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Generating CSR file...${Color_Off}"
-    openssl req -new -key ${CERTFILEBASE_FULL}.key -out ${CERTFILEBASE_FULL}.csr -config ${CONF_FILE}
+    COMM="openssl req -new -key ${CERTFILEBASE_FULL}.key -out ${CERTFILEBASE_FULL}.csr -config ${CONF_FILE}"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: ${COMM}${Color_Off}"
+    $COMM
 
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Generating TLS file (the HTTPS certificate) ...${Color_Off}"
-    openssl x509 -req -days 365 -in ${CERTFILEBASE_FULL}.csr -signkey ${CERTFILEBASE_FULL}.key -out ${CERTFILEBASE_FULL}.crt -extensions req_ext -extfile ${CERTFILEBASE_FULL}.conf
+    COMM="openssl x509 -req -days 365 -in ${CERTFILEBASE_FULL}.csr -signkey ${CERTFILEBASE_FULL}.key -out ${CERTFILEBASE_FULL}.crt -extensions req_ext -extfile ${CERTFILEBASE_FULL}.conf"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: ${COMM}${Color_Off}"
+    $COMM
 
-    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Writing instructions for Traefik how to use our certs..${Color_Off}"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Writing instructions for Traefik how to use our certs.${Color_Off}"
     echo "tls:"                                             > ${CERTS_FILE}
     echo "  stores:"                                        >> ${CERTS_FILE}
     echo "    default:"                                     >> ${CERTS_FILE}
@@ -68,7 +75,7 @@ function ld_command_tls-cert_exec() {
     echo "          keyFile: ${CERTFILENAME}.key"          >> ${CERTS_FILE}
     echo "#        - certFile: /path/to/other-domain.cert"  >> ${CERTS_FILE}
     echo "#          keyFile: /path/to/other-domain.key"    >> ${CERTS_FILE}
-    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} You may generate more certs manually, and then add the files to ./docker/certs/certs.yml file..${Color_Off}"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} You may generate more certs manually, and then add the files to ./docker/certs/certs.yml file.${Color_Off}"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} Traefik uses them if the domain matches, and generates a temporary cert if no matching cert file is found${Color_Off}"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO:${Yellow} More info in local-docker README file.${Color_Off}"
 

--- a/ld.sh
+++ b/ld.sh
@@ -70,6 +70,9 @@ if [  "$IGNORE_INIT_STATE" -eq "0" ]; then
         exit 1;
     fi
     import_config
+# Some help instructions utilize config if it exists.
+elif [ -f ".env" ]; then
+    import_config
 fi
 
 FILE=./docker/scripts/ld.command.$ACTION.sh


### PR DESCRIPTION
Add SSL/TLS cert creation to init step. Adjust docker-compose file templates and Traefik configuration to handle certs and HTTPS connections. Terminate all connections in Treafik and pass on decrypted requests.