### PR TITLE
Improve docker sync regarding themes

### DIFF
--- a/docker/docker-sync.common.yml
+++ b/docker/docker-sync.common.yml
@@ -23,6 +23,7 @@ syncs:
     sync_excludes: [
       '.git',
       'web/themes/*/node_modules',
+      # You may want to remove the following line in case you use npm to download assets used in theme libraries.
       'web/themes/*/*/node_modules',
       # When a Drupal theme uses Pattern Lab (like Emulsify does), it produces A LOT of traffic when the styles
       # compilation is being done on the host. Excluding the directory from sync will reduce docker-sync related errors.

--- a/docker/docker-sync.common.yml
+++ b/docker/docker-sync.common.yml
@@ -24,6 +24,9 @@ syncs:
       '.git',
       'web/themes/*/node_modules',
       'web/themes/*/*/node_modules',
+      # When a Drupal theme uses Pattern Lab (like Emulsify does), it produces A LOT of traffic when the styles
+      # compilation is being done on the host. Excluding the directory from sync will reduce docker-sync related errors.
+      'web/themes/custom/*/pattern-lab',
       'web/sites/*/files']
 
     sync_userid: '${DOCKER_SYNC_UID}'

--- a/docker/docker-sync.skeleton.yml
+++ b/docker/docker-sync.skeleton.yml
@@ -83,6 +83,7 @@ syncs:
     sync_excludes: [
       '.git',
       'web/themes/*/node_modules',
+      # You may want to remove the following line in case you use npm to download assets used in theme libraries.
       'web/themes/*/*/node_modules',
       # When a Drupal theme uses Pattern Lab (like Emulsify does), it produces A LOT of traffic when the styles
       # compilation is being done on the host. Excluding the directory from sync will reduce docker-sync related errors.

--- a/docker/docker-sync.skeleton.yml
+++ b/docker/docker-sync.skeleton.yml
@@ -84,6 +84,9 @@ syncs:
       '.git',
       'web/themes/*/node_modules',
       'web/themes/*/*/node_modules',
+      # When a Drupal theme uses Pattern Lab (like Emulsify does), it produces A LOT of traffic when the styles
+      # compilation is being done on the host. Excluding the directory from sync will reduce docker-sync related errors.
+      'web/themes/custom/*/pattern-lab',
       'web/sites/*/files']
     sync_userid: '${DOCKER_SYNC_UID}'
     sync_groupid: '${DOCKER_SYNC_GID}'


### PR DESCRIPTION
The change is pretty well described in the comment but here goes once more.

This change adds an exclusion pattern in the docker-sync configuration to exclude a specific directory from docker-sync. The directory is called `pattern-lab` and it is the directory where the Pattern Lab component of Drupal themes such as Emulsify generate their static sites when either `gulp build` or `npm start` is used.

Especially with `npm start`, which starts a watcher on local, the changes to the `pattern-lab` directory are so frequent that the unison process can't keep up and docker-sync grinds to a halt.