### PR TITLE
Improve documentation of phpcf and phpcbf commands

### DIFF
--- a/docker/scripts/ld.command.phpcbf.sh
+++ b/docker/scripts/ld.command.phpcbf.sh
@@ -27,5 +27,5 @@ function ld_command_phpcbf_extended_help() {
     echo "dealerdirect/phpcodesniffer-composer-installer package has been installed."
     echo "To target e.g. your custom modules, use /var/www/web/modules/custom as the argument."
     echo
-    echo "Example: $SCRIPT_NAME_SHORT phpcbf --standard=Drupal,DrupalPractice /var/www/web/modules/custom"
+    echo "Example: $SCRIPT_NAME_SHORT phpcbf --extensions=module,theme,php,inc --standard=Drupal,DrupalPractice /var/www/web/modules/custom"
 }

--- a/docker/scripts/ld.command.phpcs.sh
+++ b/docker/scripts/ld.command.phpcs.sh
@@ -27,5 +27,5 @@ function ld_command_phpcs_extended_help() {
     echo "dealerdirect/phpcodesniffer-composer-installer package has been installed."
     echo "To target e.g. your custom modules, use /var/www/web/modules/custom as the argument."
     echo
-    echo "Example: $SCRIPT_NAME_SHORT phpcs --standard=Drupal,DrupalPractice /var/www/web/modules/custom"
+    echo "Example: $SCRIPT_NAME_SHORT phpcs --extensions=module,theme,php,inc --standard=Drupal,DrupalPractice /var/www/web/modules/custom"
 }


### PR DESCRIPTION
I discovered that both commands need explicit extension lists to
function correctly.

Without the extension list the file list the tool builds will only
contain files with the extension .php.

