### PR TITLE
131 add git repo massager

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ and start the initialisation.
     $ cd my-project
     $ ./ld init [TEMPLATE-NAME]
 
-Init will ask you new Git repository address and flattens the local-docker
+Init will ask you for your new Git repository address and flatten the local-docker
 commit history to single init commit.
 
 It will ask you details about your project and set your local development up

--- a/README.md
+++ b/README.md
@@ -73,22 +73,13 @@ and start the initialisation.
 
     $ git clone git@github.com:Exove/local-docker.git my-project
     $ cd my-project
-    # Reconfigure first git remote 'origin' (so you do not push to
-    # local-docker -repository by mistake).
-    $ git remote set-url origin ssh://git.example.com/my-project.git
-    # Verify you have correct remote url's.
-    $ git remote -v
-    # Create a disconnected temporary branch w/ no commits. This new
-    # branch is not connected to the old repository branches.
-    $ git checkout --orphan master-new
-    # Commit clean project base to the new and still empty branch.
-    $ git commit -am 'Initial commit for my-project from local-docker'
-    # Delete old master branch (with the full commit history), and
-    # rename your temporary branch to master.
-    $ git branch -D master
-    $ git branch -m master-new master
-    $ git push
     $ ./ld init [TEMPLATE-NAME]
+
+Init will ask you new Git repository address and flattens the local-docker
+commit history to single init commit.
+
+It will ask you details about your project and set your local development up
+based on the information provided. Finally it will start your local.
 
 #### Existing project
 

--- a/docker/scripts/ld.command.git-repo-massage.sh
+++ b/docker/scripts/ld.command.git-repo-massage.sh
@@ -30,12 +30,12 @@ function ld_command_git-repo-massage_exec() {
             echo "If you leave this empty Git remote will not be edited."
             read -p "Git repository address: " ANSWER
              # Very simple test to see we have .git at the end of remote url.
-            TEST=$(echo $ANSWER | egrep -e '.*\.git$')
-            if [ -z "$ANSWER" ] || [ "${#TEST}" -gt 0 ]; then
+            TEST_HAS_DOTGIT=$(echo $ANSWER | egrep -e '.*\.git$')
+            TEST_HAS_SPACES=$(echo $ANSWER | egrep -e '\s')
+            if [ -z "$ANSWER" ] || ( [ "${#TEST_HAS_DOTGIT}" -gt "0" ] && [ "${#TEST_HAS_SPACES}" -eq "0" ] ); then
                 VALID=1
             else
-                echo -e "${Red}ERROR: Git repository address is invalid. Please try again.${Color_Off}"
-                sleep 1
+                echo -e "${Red}ERROR: Git repository address is invalid. Please try again. No spaces allowed, must end with '.git'.${Color_Off}"
                 echo
             fi
         done

--- a/docker/scripts/ld.command.git-repo-massage.sh
+++ b/docker/scripts/ld.command.git-repo-massage.sh
@@ -39,7 +39,7 @@ function ld_command_git-repo-massage_exec() {
                 echo
             fi
         done
-        if [ ! -z "$ANSWER" ]; then
+        if [ -n "$ANSWER" ]; then
             git remote set-url origin $ANSWER
             [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO: ${Yellow}Git remotes (all):" && git remote -v
             [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Color_Off}"

--- a/docker/scripts/ld.command.git-repo-massage.sh
+++ b/docker/scripts/ld.command.git-repo-massage.sh
@@ -15,7 +15,7 @@ function ld_command_git-repo-massage_exec() {
     [ "$LD_VERBOSE" -ge "2" ] && [ "$GIT_COMMIT_MATCH" -gt "0" ] && echo "Initial Git commit matches known initial commit hash in Exove/local-docker.git"
 
     # This catches both https and ssh based remote addresses.
-    GIT_REPO_MATCH=$(git config --get remote.origin.url | grep -c 'Exove/local-docker.git')
+    GIT_REPO_MATCH=$(git config --get remote.origin.url | egrep -c 'Exove\/local\-docker\.git$')
 
     [ "$LD_VERBOSE" -ge "2" ] && [ "$GIT_REPO_MATCH" -gt "0" ] && echo "Git repository is connected to Exove/local-docker.git"
 

--- a/docker/scripts/ld.command.git-repo-massage.sh
+++ b/docker/scripts/ld.command.git-repo-massage.sh
@@ -64,12 +64,13 @@ function ld_command_git-repo-massage_exec() {
 }
 
 function ld_command_git-repo-massage_help() {
-    echo "Tries to flatten your git history and update remote paths. 1st argument set to FORCE ignores security checks and flattens your local master branch history to single commit."
+    echo "Tries to flatten your git history and update remote paths."
+#    echo "Tries to flatten your git history and update remote paths. 1st argument set to FORCE ignores security checks and flattens your local master branch history to single commit."
 }
 
 function ld_command_git-repo-massage_extended_help() {
     echo "This is used to clean project repository history and to connect repository to new project remote."
     echo
     echo "Example: $SCRIPT_NAME_SHORT git-repo-massage "
-    echo "Example: $SCRIPT_NAME_SHORT git-repo-massage FORCE # to ignore commit hash checks"
+#    echo "Example: $SCRIPT_NAME_SHORT git-repo-massage FORCE # to ignore commit hash checks"
 }

--- a/docker/scripts/ld.command.git-repo-massage.sh
+++ b/docker/scripts/ld.command.git-repo-massage.sh
@@ -51,7 +51,9 @@ function ld_command_git-repo-massage_exec() {
         [ "$LD_VERBOSE" -ge "1" ] && echo -ne "${BYellow}INFO: ${Yellow}Your Git history will be reduce to a single commit now (in 5 secs)."
         [ "$LD_VERBOSE" -ge "1" ] && timer 5
         git checkout --orphan master-new
-        git commit -am "Initial commit from local-docker v.${LOCAL_DOCKER_VERSION}"
+        # Remove files related to local-dockers Github repository management.
+        rm -rf .github
+        git commit -aqm "Initial commit from local-docker v.${LOCAL_DOCKER_VERSION}"
         git branch -D master
         git branch -m master-new master
     else

--- a/docker/scripts/ld.command.git-repo-massage.sh
+++ b/docker/scripts/ld.command.git-repo-massage.sh
@@ -67,12 +67,10 @@ function ld_command_git-repo-massage_exec() {
 
 function ld_command_git-repo-massage_help() {
     echo "Tries to flatten your git history and update remote paths."
-#    echo "Tries to flatten your git history and update remote paths. 1st argument set to FORCE ignores security checks and flattens your local master branch history to single commit."
 }
 
 function ld_command_git-repo-massage_extended_help() {
     echo "This is used to clean project repository history and to connect repository to new project remote."
     echo
     echo "Example: $SCRIPT_NAME_SHORT git-repo-massage "
-#    echo "Example: $SCRIPT_NAME_SHORT git-repo-massage FORCE # to ignore commit hash checks"
 }

--- a/docker/scripts/ld.command.git-repo-massage.sh
+++ b/docker/scripts/ld.command.git-repo-massage.sh
@@ -15,7 +15,7 @@ function ld_command_git-repo-massage_exec() {
     [ "$LD_VERBOSE" -ge "2" ] && [ "$GIT_COMMIT_MATCH" -gt "0" ] && echo "Initial Git commit matches known initial commit hash in Exove/local-docker.git"
 
     # This catches both https and ssh based remote addresses.
-    GIT_REPO_MATCH=$(git config --get remote.origin.url | egrep -c 'Exove\/local\-docker\.git$')
+    GIT_REPO_MATCH=$(git config --get remote.origin.url | grep -e -c 'Exove\/local\-docker\.git$')
 
     [ "$LD_VERBOSE" -ge "2" ] && [ "$GIT_REPO_MATCH" -gt "0" ] && echo "Git repository is connected to Exove/local-docker.git"
 

--- a/docker/scripts/ld.command.git-repo-massage.sh
+++ b/docker/scripts/ld.command.git-repo-massage.sh
@@ -48,8 +48,8 @@ function ld_command_git-repo-massage_exec() {
     fi
 
     if [ "$GIT_COMMIT_MATCH" -gt "0" ] && [ "$GIT_REPO_MATCH" -eq "0" ]; then
-        [ "$LD_VERBOSE" -ge "1" ] && echo -e "${BYellow}INFO: ${Yellow}Your Git history will be reduce to a single commit now (in 4 secs)."
-        sleep 4
+        [ "$LD_VERBOSE" -ge "1" ] && echo -ne "${BYellow}INFO: ${Yellow}Your Git history will be reduce to a single commit now (in 5 secs)."
+        [ "$LD_VERBOSE" -ge "1" ] && timer 5
         git checkout --orphan master-new
         git commit -am "Initial commit from local-docker v.${LOCAL_DOCKER_VERSION}"
         git branch -D master

--- a/docker/scripts/ld.command.git-repo-massage.sh
+++ b/docker/scripts/ld.command.git-repo-massage.sh
@@ -29,7 +29,7 @@ function ld_command_git-repo-massage_exec() {
             echo "It is YOUR responsibility to ensure it is correct and functional. However local-docker does not touch your git remote, ever."
             echo "If you leave this empty Git remote will not be edited."
             read -p "Git repository address: " ANSWER
-#            # Very simple test to see we have .git at the end of remote url.
+             # Very simple test to see we have .git at the end of remote url.
             TEST=$(echo $ANSWER | egrep -e '.*\.git$')
             if [ -z "$ANSWER" ] || [ "${#TEST}" -gt 0 ]; then
                 VALID=1

--- a/docker/scripts/ld.command.git-repo-massage.sh
+++ b/docker/scripts/ld.command.git-repo-massage.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# File
+#
+# This file contains git-repo-massage -command for local-docker script ld.sh.
+
+function ld_command_git-repo-massage_exec() {
+
+    if [ ! -d ".git" ]; then
+        echo -e "${Red}ERROR: Could not locate Git repository (.git folder missing).${Color_Off}"
+        return 1
+    fi
+
+    # Check if we have initial local-docker commit in git history.
+    GIT_COMMIT_MATCH=$(git rev-list HEAD | tail -n 1 |grep -c "99c1a03ce16f2ff1fe33bc136e09fcbcb0fd5397" )
+    [ "$LD_VERBOSE" -ge "2" ] && [ "$GIT_COMMIT_MATCH" -gt "0" ] && echo "Initial Git commit matches known initial commit hash in Exove/local-docker.git"
+
+    # This catches both https and ssh based remote addresses.
+    GIT_REPO_MATCH=$(git config --get remote.origin.url | grep -c 'Exove/local-docker.git')
+
+    [ "$LD_VERBOSE" -ge "2" ] && [ "$GIT_REPO_MATCH" -gt "0" ] && echo "Git repository is connected to Exove/local-docker.git"
+
+    if [ "$GIT_REPO_MATCH" -gt "0" ]; then
+        echo -e "${BYellow}NOTE${Yellow}: You are still connected to ${BYellow}Exove/local-docker.git${Yellow}.${Color_Off}"
+        VALID=
+        echo
+        echo -e "${BBlack}== GIT repository address ==${Color_Off}"
+        while [ -z "$VALID" ]; do
+            echo "What is your Git repository address?"
+            echo "It is YOUR responsibility to ensure it is correct and functional. However local-docker does not touch your git remote, ever."
+            echo "If you leave this empty Git remote will not be edited."
+            read -p "Git repository address: " ANSWER
+#            # Very simple test to see we have .git at the end of remote url.
+            TEST=$(echo $ANSWER | egrep -e '.*\.git$')
+            if [ -z "$ANSWER" ] || [ "${#TEST}" -gt 0 ]; then
+                VALID=1
+            else
+                echo -e "${Red}ERROR: Git repository address is invalid. Please try again.${Color_Off}"
+                sleep 1
+                echo
+            fi
+        done
+        if [ ! -z "$ANSWER" ]; then
+            git remote set-url origin $ANSWER
+            [ "$LD_VERBOSE" -ge "2" ] && echo -e "${BYellow}INFO: ${Yellow}Git remotes (all):" && git remote -v
+            [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Color_Off}"
+            GIT_REPO_MATCH=0
+        fi
+    fi
+
+    if [ "$GIT_COMMIT_MATCH" -gt "0" ] && [ "$GIT_REPO_MATCH" -eq "0" ]; then
+        [ "$LD_VERBOSE" -ge "1" ] && echo -e "${BYellow}INFO: ${Yellow}Your Git history will be reduce to a single commit now (in 4 secs)."
+        sleep 4
+        git checkout --orphan master-new
+        git commit -am "Initial commit from local-docker v.${LOCAL_DOCKER_VERSION}"
+        git branch -D master
+        git branch -m master-new master
+    else
+        [ "$LD_VERBOSE" -ge "2" ] && echo "Commit hash check done, looks like the the git history has been massaged already."
+    fi
+
+    # In case all checks failed, we must return 0 to have some SIGINT value for
+    # the main script.
+    return 0
+}
+
+function ld_command_git-repo-massage_help() {
+    echo "Tries to flatten your git history and update remote paths. 1st argument set to FORCE ignores security checks and flattens your local master branch history to single commit."
+}
+
+function ld_command_git-repo-massage_extended_help() {
+    echo "This is used to clean project repository history and to connect repository to new project remote."
+    echo
+    echo "Example: $SCRIPT_NAME_SHORT git-repo-massage "
+    echo "Example: $SCRIPT_NAME_SHORT git-repo-massage FORCE # to ignore commit hash checks"
+}

--- a/docker/scripts/ld.command.git-repo-massage.sh
+++ b/docker/scripts/ld.command.git-repo-massage.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # File
 #
-# This file contains git-repo-massage -command for local-docker script ld.sh.
+# This file contains git-repo-massage command for local-docker script ld.sh.
 
 function ld_command_git-repo-massage_exec() {
 

--- a/docker/scripts/ld.command.git-repo-massage.sh
+++ b/docker/scripts/ld.command.git-repo-massage.sh
@@ -15,7 +15,7 @@ function ld_command_git-repo-massage_exec() {
     [ "$LD_VERBOSE" -ge "2" ] && [ "$GIT_COMMIT_MATCH" -gt "0" ] && echo "Initial Git commit matches known initial commit hash in Exove/local-docker.git"
 
     # This catches both https and ssh based remote addresses.
-    GIT_REPO_MATCH=$(git config --get remote.origin.url | grep -e -c 'Exove\/local\-docker\.git$')
+    GIT_REPO_MATCH=$(git config --get remote.origin.url | grep -c -E 'Exove\/local\-docker\.git$')
 
     [ "$LD_VERBOSE" -ge "2" ] && [ "$GIT_REPO_MATCH" -gt "0" ] && echo "Git repository is connected to Exove/local-docker.git"
 

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -35,6 +35,12 @@ function ld_command_init_exec() {
         esac
     fi
 
+    # Check first to flatten the git repo history fully.
+    # Git repo must match local-docker origin and commit has be known initial
+    # commit has of local-docker.
+    # Without these matching nothing will be done.
+    $SCRIPT_NAME git-repo-massage
+
     echo
     echo -e "${BBlack}== General setup ==${Color_Off}"
 

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -258,7 +258,8 @@ function project_config_file_check () {
 # @param int
 #   Number of seconds to spend timing.
 function timer () {
-    WAIT=${1:-5}
+    # Make any string to integer, defaulting to 5 (seconds).
+    WAIT=$((${1:-5} + 0))
     # Both .env AND docker-compose.yml file must be present to define project as initialized.
     while [ $WAIT -gt 0 ]; do
         echo -n "."

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -250,3 +250,20 @@ function project_config_file_check () {
 
     return 0
 }
+
+# Timer.
+#
+# Echoes dot per second.
+#
+# @param int
+#   Number of seconds to spend timing.
+function timer () {
+    WAIT=${1:-5}
+    # Both .env AND docker-compose.yml file must be present to define project as initialized.
+    while [ $WAIT -gt 0 ]; do
+        echo -n "."
+        ((WAIT--))
+        sleep 1
+    done
+    echo
+}

--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Source: https://github.com/manoj-apare/pre-commit, slightly modified.
 #
@@ -109,7 +109,7 @@ if [ -n "$files_changed" ]; then
       # Find debugging function exists in file diff one by one.
       pattern="^\+(.*)?$keyword\s*\((.*)?"
       result_for_file=`git diff --cached $FILE | egrep -x "$pattern"`
-      if [ ! -z "$result_for_file" ]; then
+      if [ -n "$result_for_file" ]; then
         debugging_function_found=1
         errors_found=$((errors_found + 1))
         if [ $debugging_function_found -eq 1 ]; then
@@ -163,7 +163,7 @@ if [ -n "$files_changed" ]; then
     # Find debugging function exists in file diff one by one.
     pattern="(<<<<|====|>>>>)+.*(\n)?"
     result_for_file=`egrep -in "$pattern" $FILE`
-    if [ ! -z "$result_for_file" ]; then
+    if [ -n "$result_for_file" ]; then
       merge_conflict_marker=1
       errors_found=$((errors_found + 1))
       if [ $merge_conflict_marker -eq 1 ]; then

--- a/ld.sh
+++ b/ld.sh
@@ -50,7 +50,7 @@ else
 fi
 
 IGNORE_INIT_STATE=0
-WHITELIST_COMMANDS=("help" "self-update" "init")
+WHITELIST_COMMANDS=("help" "self-update" "init" "git-repo-massage")
 element_in "$ACTION" "${WHITELIST_COMMANDS[@]}"
 if [ "$?" -eq "0" ]; then
     IGNORE_INIT_STATE=1


### PR DESCRIPTION
Adding git-repo-massage -command and it using in during `./ld init` to reset the Git history (flatten to a single command).

The command checks we are on a different Git repo (not Exove/local-docker), and that the commit history does not have the know first commit of local-docker.

In other words; it does wipe your existing project master.