### PR TITLE
Drupal template updates to match current releases

### DIFF
--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -256,6 +256,10 @@ function ld_command_init_exec() {
     echo "Please select which version of drupal you wish to have."
     echo "Alternatively you can install your codebase manually into $APP_ROOT."
     echo "Options:"
+    echo " [9.0] - Drupal 8.9 recommended (drupal/recommended-project:~9.0.0)"
+    echo " [9.0-dev] - Drupal 9.0 recommended (drupal/recommended-project:~9.0.0) with dev-stability"
+    echo " [8.9] - Drupal 8.9 recommended (drupal/recommended-project:~8.9.0)"
+    echo " [8.9-dev] - Drupal 8.9 recommended (drupal/recommended-project:~8.9.0) with dev-stability"
     echo " [8.8] - Drupal 8.8 recommended (drupal/recommended-project:~8.8.0)"
     echo " [8.8-dev] - Drupal 8.8 recommended (drupal/recommended-project:~8.8.0) with dev-stability"
     echo " [8.8-legacy] - Drupal 8.8 legacy (drupal/legacy-project:~8.8.0)"
@@ -263,6 +267,26 @@ function ld_command_init_exec() {
     read -p "Select version [default: ${DEFAULT}]? " VERSION
     VERSION=${VERSION:-${DEFAULT}}
     case "$VERSION" in
+      '9.0')
+        COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~9.0.0 /var/www --no-interaction'
+        POST_COMPOSER_INIT='composer -vv require drupal/console:^1.9.4 drush/drush:^10.0 cweagans/composer-patches:~1.0'
+        echo -e "${Green}Creating project using ${BGreen}Drupal 9.0.x${Green}, recommended structure (${BGreen}drupal/recommended-project:~9.0.0${Green}), with the addition of Drupal Console, Drush and composer patches.${Color_Off}"
+        ;;
+      '9.0-dev')
+        COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~9.0.0 /var/www --no-interaction --stability=dev'
+        POST_COMPOSER_INIT='composer -vv require drupal/console:^1.9.4 drush/drush:^10.0 cweagans/composer-patches:~1.0'
+        echo -e "${Green}Creating project using ${BGreen}Drupal 9.0.x (dev)${Green}, recommended structure (${BGreen}drupal/recommended-project:~9.0.0${Green}), with the addition of Drupal Console, Drush and composer patches.${Color_Off}"
+        ;;
+      '8.9')
+        COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~8.9.0 /var/www --no-interaction'
+        POST_COMPOSER_INIT='composer -vv require drupal/console:^1.9.4 drush/drush:^10.0 cweagans/composer-patches:~1.0'
+        echo -e "${Green}Creating project using ${BGreen}Drupal 8.9.x${Green}, recommended structure (${BGreen}drupal/recommended-project:~8.9.0${Green}), with the addition of Drupal Console, Drush and composer patches.${Color_Off}"
+        ;;
+      '8.9-dev')
+        COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~8.9.0 /var/www --no-interaction --stability=dev'
+        POST_COMPOSER_INIT='composer -vv require drupal/console:^1.9.4 drush/drush:^10.0 cweagans/composer-patches:~1.0'
+        echo -e "${Green}Creating project using ${BGreen}Drupal 8.9.x (dev)${Green}, recommended structure (${BGreen}drupal/recommended-project:~8.9.0${Green}), with the addition of Drupal Console, Drush and composer patches.${Color_Off}"
+        ;;
       '8.8')
         COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~8.8.0 /var/www --no-interaction'
         POST_COMPOSER_INIT='composer -vv require drupal/console:^1.9.4 drush/drush:^10.0 cweagans/composer-patches:~1.0'

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -259,7 +259,6 @@ function ld_command_init_exec() {
     echo " [8.8] - Drupal 8.8 recommended (drupal/recommended-project:~8.8.0)"
     echo " [8.8-dev] - Drupal 8.8 recommended (drupal/recommended-project:~8.8.0) with dev-stability"
     echo " [8.8-legacy] - Drupal 8.8 legacy (drupal/legacy-project:~8.8.0)"
-    echo " [8.7] - Drupal 8.7 using contrib template (drupal-composer/drupal-project:8.x-dev)"
     echo " [N] - Thanks for the offer, but I'll handle codebase build manually."
     read -p "Select version [default: ${DEFAULT}]? " VERSION
     VERSION=${VERSION:-${DEFAULT}}
@@ -278,10 +277,6 @@ function ld_command_init_exec() {
         COMPOSER_INIT='composer -vv create-project drupal/legacy-project:~8.8.0 /var/www --no-interaction --stability=dev'
         POST_COMPOSER_INIT='composer -vv require drupal/console:^1.9.4 drush/drush:^10.0 cweagans/composer-patches:~1.0'
         echo -e "${Green}Creating project using ${BGreen}Drupal 8.8.x${Green}, legacy structure (${BGreen}drupal/legacy-project:~8.8.0${Green}), with the addition of Drupal Console, Drush and composer patches.${Color_Off}"
-        ;;
-      '8.7')
-        COMPOSER_INIT='composer -vv create-project drupal-composer/drupal-project:8.x-dev /var/www --no-interaction --stability=dev'
-        echo -e "${Green}Creating project using ${BGreen}Drupal 8.7.x${Green}, contrib template (drupal-composer/drupal-project:8.x-dev).${Color_Off}"
         ;;
       *)
         echo -e "${BYellow}Build phase skipped, no codebase built!${Color_Off}"

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -268,22 +268,22 @@ function ld_command_init_exec() {
     VERSION=${VERSION:-${DEFAULT}}
     case "$VERSION" in
       '9.0')
-        COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~9.0.0 /var/www --no-interaction'
+        COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~9.0.0 . --no-interaction'
         POST_COMPOSER_INIT='composer -vv require drupal/console:^1.9.4 drush/drush:^10.0 cweagans/composer-patches:~1.0'
         echo -e "${Green}Creating project using ${BGreen}Drupal 9.0.x${Green}, recommended structure (${BGreen}drupal/recommended-project:~9.0.0${Green}), with the addition of Drupal Console, Drush and composer patches.${Color_Off}"
         ;;
       '9.0-dev')
-        COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~9.0.0 /var/www --no-interaction --stability=dev'
+        COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~9.0.0 . --no-interaction --stability=dev'
         POST_COMPOSER_INIT='composer -vv require drupal/console:^1.9.4 drush/drush:^10.0 cweagans/composer-patches:~1.0'
         echo -e "${Green}Creating project using ${BGreen}Drupal 9.0.x (dev)${Green}, recommended structure (${BGreen}drupal/recommended-project:~9.0.0${Green}), with the addition of Drupal Console, Drush and composer patches.${Color_Off}"
         ;;
       '8.9')
-        COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~8.9.0 /var/www --no-interaction'
+        COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~8.9.0 . --no-interaction'
         POST_COMPOSER_INIT='composer -vv require drupal/console:^1.9.4 drush/drush:^10.0 cweagans/composer-patches:~1.0'
         echo -e "${Green}Creating project using ${BGreen}Drupal 8.9.x${Green}, recommended structure (${BGreen}drupal/recommended-project:~8.9.0${Green}), with the addition of Drupal Console, Drush and composer patches.${Color_Off}"
         ;;
       '8.9-dev')
-        COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~8.9.0 /var/www --no-interaction --stability=dev'
+        COMPOSER_INIT='composer -vv create-project drupal/recommended-project:~8.9.0 . --no-interaction --stability=dev'
         POST_COMPOSER_INIT='composer -vv require drupal/console:^1.9.4 drush/drush:^10.0 cweagans/composer-patches:~1.0'
         echo -e "${Green}Creating project using ${BGreen}Drupal 8.9.x (dev)${Green}, recommended structure (${BGreen}drupal/recommended-project:~8.9.0${Green}), with the addition of Drupal Console, Drush and composer patches.${Color_Off}"
         ;;

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -251,7 +251,7 @@ function ld_command_init_exec() {
 
     echo
     echo -e "${BBlack}== Installing Drupal project ==${Color_Off}"
-    DEFAULT=8.8
+    DEFAULT=9.0
 
     echo "Please select which version of drupal you wish to have."
     echo "Alternatively you can install your codebase manually into $APP_ROOT."


### PR DESCRIPTION
Add Drupal 8.9 and Drupal 9.0 as options for `./ld init` initiated composer templates.

Remove unsupported Drupal 8.7 from the same list.