### PR TITLE
Add instructions to set up ld alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Source the file (or start a new shell window) and you can use `ld` to execute
 your local-docker commands.
 
 In order to not interfere with [`/usr/bin/ld`](https://linux.die.net/man/1/ld), you may use another name besides
-`ld` as function name. However, it is quite rarely used command.
+`ld` as function name. However, it is quite rarely used a command.
 
 #### Update local-docker itself
 

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Add this to your `~/.zshrc` or `~/.bashrc`:
 Source the file (or start a new shell window) and you can use `ld` to execute
 your local-docker commands.
 
-In order to not interfere with `/usr/bin/ld`, you may use another name besides
+In order to not interfere with [`/usr/bin/ld`](https://linux.die.net/man/1/ld), you may use another name besides
 `ld` as function name. However, it is quite rarely used command.
 
 #### Update local-docker itself

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Add this to your `~/.zshrc` or `~/.bashrc`:
             echo "ld.sh not found in this or any of the parent directories. Traversed up the tree until reached home directory ($HOME)."
             return 1
           elif [ "${#NEXT_UP}" -eq "1"  ]; then
-            echo "ld.sh not found in this or any of the parent folders. Traversed up the tree until reached the filesystem root."
+            echo "ld.sh not found in this or any of the parent directories. Traversed up the tree until reached the filesystem root."
             return 1
           fi
           CURRENTLY_CHECKED=$NEXT_UP

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Add this to your `~/.zshrc` or `~/.bashrc`:
           # Pass the recevied return code as-is.
           return $?
         else
-          # Shorten the folder path by one directory.
+          # Shorten the directory path by one.
           NEXT_UP=`dirname $CURRENTLY_CHECKED`
           #If we reached the user's home folder stop.
           if [ "$CURRENTLY_CHECKED" = "$HOME" ]; then

--- a/README.md
+++ b/README.md
@@ -439,15 +439,55 @@ for IDE to setup a Xdebug listener to the port Xdebug is trying to
 connect to on your host. Port `9010` is being used to avoid collision
 with possible running `php-fpm` on the host machine port `9000`.
 
-#### Convenience "alias" for ./ld.sh
+#### Project level alias for ./ld.sh
 
-If you find the `./` prefix tedious when using ld, you could add the following
-alias to your shell startup files. In order to not interfere with `/usr/bin/ld`,
-`ld` as alias should be avoided.
+You can set up a "local-docker finder" via Bash/Zsh function, which will try to
+find the project's ld.sh script, and pass command name and other argumets to it.
 
-    function lld() { if [[ -x "$(pwd)/ld.sh" ]] ; then "$(pwd)/ld.sh" $@; else echo "ld.sh not found in current directory"; fi }
+Add this to your `~/.zshrc` or `~/.bashrc`:
 
-Then, you can use `lld` instead of `./ld` or `./ld.sh`
+    # Local-docker tool
+    #
+    # This shell function travers upwards in the folder tree starting form the
+    # current folder up to user's home folder (or filesystem root).
+    # If ld.sh file is found and is executable shell script, execute it passing all
+    # provided paramters to it.
+    #
+    function ld() {
+      CURRENTLY_CHECKED=`pwd`
+      FOUND=
+
+      while [ "${#CURRENTLY_CHECKED}" -gt "1"  ] && [ –z "$FOUND"] ; do
+
+        [ -x "${CURRENTLY_CHECKED}/ld.sh" ] && FOUND=1
+
+        if [ "$FOUND" -eq "1" ]; then
+          ${CURRENTLY_CHECKED}/ld.sh "$@"
+          # Pass the recevied return code as-is.
+          return $?
+        else
+          # Shorten the folder path by one directory.
+          NEXT_UP=`dirname $CURRENTLY_CHECKED`
+          #If we reached the user's home folder stop.
+          if [ "$CURRENTLY_CHECKED" = "$HOME" ]; then
+            echo "ld.sh not found in this or any of the parent folders. Traversed up the tree until reached home folder ($HOME)."
+            return 1
+          elif [ "${#NEXT_UP}" -eq "1"  ]; then
+            echo "ld.sh not found in this or any of the parent folders. Traversed up the tree until reached the filesystem root."
+            return 1
+          fi
+          CURRENTLY_CHECKED=$NEXT_UP
+        fi
+
+      done
+    }
+
+
+Source the file (or start a new shell window) and you can use `ld` to execute
+your local-docker commands.
+
+In order to not interfere with `/usr/bin/ld`, you may use another name besides
+`ld` as function name. However, it is quite rarely used command.
 
 #### Update local-docker itself
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Add this to your `~/.zshrc` or `~/.bashrc`:
     #
     # This shell function travers upwards in the folder tree starting form the
     # current folder and up to the user's home folder (or filesystem root).
-    # If ld.sh file is found and is executable shell script, execute it passing
+    # If the ld.sh file is found and is an executable shell script, execute it passing
     # all provided arguments forward.
     #
     function ld() {

--- a/README.md
+++ b/README.md
@@ -459,9 +459,9 @@ Add this to your `~/.zshrc` or `~/.bashrc`:
 
       while [ "${#CURRENTLY_CHECKED}" -gt "1"  ] && [ –z "$FOUND"] ; do
 
-        [ -x "${CURRENTLY_CHECKED}/ld.sh" ] && FOUND=1
+        [ -x "${CURRENTLY_CHECKED}/ld.sh" ] && FOUND="1"
 
-        if [ "$FOUND" -eq "1" ]; then
+        if [ -n "$FOUND" ]; then
           ${CURRENTLY_CHECKED}/ld.sh "$@"
           # Pass the recevied return code as-is.
           return $?

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Add this to your `~/.zshrc` or `~/.bashrc`:
           NEXT_UP=`dirname $CURRENTLY_CHECKED`
           #If we reached the user's home folder stop.
           if [ "$CURRENTLY_CHECKED" = "$HOME" ]; then
-            echo "ld.sh not found in this or any of the parent folders. Traversed up the tree until reached home folder ($HOME)."
+            echo "ld.sh not found in this or any of the parent directories. Traversed up the tree until reached home directory ($HOME)."
             return 1
           elif [ "${#NEXT_UP}" -eq "1"  ]; then
             echo "ld.sh not found in this or any of the parent folders. Traversed up the tree until reached the filesystem root."

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ Add this to your `~/.zshrc` or `~/.bashrc`:
 
     # Local-docker tool
     #
-    # This shell function travers upwards in the folder tree starting form the
+    # This shell function travels upwards in the directory tree starting from the
     # current directory and up to the user's home directory (or filesystem root).
     # If the ld.sh file is found and is an executable shell script, execute it passing
     # all provided arguments forward.

--- a/README.md
+++ b/README.md
@@ -449,9 +449,9 @@ Add this to your `~/.zshrc` or `~/.bashrc`:
     # Local-docker tool
     #
     # This shell function travers upwards in the folder tree starting form the
-    # current folder up to user's home folder (or filesystem root).
-    # If ld.sh file is found and is executable shell script, execute it passing all
-    # provided paramters to it.
+    # current folder and up to the user's home folder (or filesystem root).
+    # If ld.sh file is found and is executable shell script, execute it passing
+    # all provided arguments forward.
     #
     function ld() {
       CURRENTLY_CHECKED=`pwd`

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Add this to your `~/.zshrc` or `~/.bashrc`:
     # Local-docker tool
     #
     # This shell function travers upwards in the folder tree starting form the
-    # current folder and up to the user's home folder (or filesystem root).
+    # current directory and up to the user's home directory (or filesystem root).
     # If the ld.sh file is found and is an executable shell script, execute it passing
     # all provided arguments forward.
     #

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ Add this to your `~/.zshrc` or `~/.bashrc`:
 
         if [ -n "$FOUND" ]; then
           ${CURRENTLY_CHECKED}/ld.sh "$@"
-          # Pass the recevied return code as-is.
+          # Pass the received return code as-is.
           return $?
         else
           # Shorten the directory path by one.

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ Add this to your `~/.zshrc` or `~/.bashrc`:
         else
           # Shorten the directory path by one.
           NEXT_UP=`dirname $CURRENTLY_CHECKED`
-          #If we reached the user's home folder stop.
+          #If we reached the user's home directory, stop.
           if [ "$CURRENTLY_CHECKED" = "$HOME" ]; then
             echo "ld.sh not found in this or any of the parent directories. Traversed up the tree until reached home directory ($HOME)."
             return 1


### PR DESCRIPTION
With these instructions users should be able to set up a shell function (alias) which will find the nearest ld.sh, execute it with all provided parameters and return the return code it received. 

If no ld.sh is found, then user is notified.