### PR TITLE
Remove memory limit always when running composer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,8 @@ PROJECT_PHP_VERSION=
 
 # Let the composer run as root without constant complaining.
 COMPOSER_ALLOW_SUPERUSER=1
+# Unset the composer memory limit by default.
+COMPOSER_MEMORY_LIMIT=-1
 
 # These are used (if are) during php container build phase.
 # changing these values should be followed by either:

--- a/docker/scripts/ld.command.composer.sh
+++ b/docker/scripts/ld.command.composer.sh
@@ -14,7 +14,7 @@ function ld_command_composer_exec() {
       return 2
     fi
 
-    COMM="docker-compose exec -T ${CONTAINER_PHP:-php} /usr/local/bin/composer -vv $@"
+    COMM="docker-compose exec -T -e COMPOSER_MEMORY_LIMIT=-1 ${CONTAINER_PHP:-php} /usr/local/bin/composer -vv $@"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
     $COMM
 }

--- a/docker/scripts/ld.command.composer.sh
+++ b/docker/scripts/ld.command.composer.sh
@@ -14,7 +14,7 @@ function ld_command_composer_exec() {
       return 2
     fi
 
-    COMM="docker-compose exec -T -e COMPOSER_MEMORY_LIMIT=-1 ${CONTAINER_PHP:-php} /usr/local/bin/composer -vv $@"
+    COMM="docker-compose exec -T ${CONTAINER_PHP:-php} /usr/local/bin/composer -vv $@"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
     $COMM
 }


### PR DESCRIPTION
It would be feasible also to document adding the environment variable in `.env.local` for example on a per-need basis, but in practice using composer to do anything other than `install` almost always makes it run out of memory, especially on 1.x versions.

That's why I'm offering this simple solution of passing the `COMPOSER_MEMORY_LIMIT=-1` environment variable all the time when running composer commands.