### PR TITLE
Wrap calls to docker-compose with a callback

### DIFF
--- a/docker/scripts/ld.command.composer.sh
+++ b/docker/scripts/ld.command.composer.sh
@@ -14,7 +14,7 @@ function ld_command_composer_exec() {
       return 2
     fi
 
-    COMM="docker-compose exec -T ${CONTAINER_PHP:-php} /usr/local/bin/composer -vv $@"
+    COMM=$(compose_command) " exec -T ${CONTAINER_PHP:-php} /usr/local/bin/composer -vv $@"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
     $COMM
 }

--- a/docker/scripts/ld.command.db-backup.sh
+++ b/docker/scripts/ld.command.db-backup.sh
@@ -24,7 +24,7 @@ function ld_command_db-backup_exec() {
           ;;
 
         2|"2")
-          COMM="docker-compose -f $DOCKER_COMPOSE_FILE  up -d $CONTAINER_DB"
+          COMM=$(compose_command) " -f $DOCKER_COMPOSE_FILE  up -d $CONTAINER_DB"
           [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Yellow}Starting DB container for backup purposes.${Color_Off}"
           $COMM
           STARTED=1
@@ -37,15 +37,15 @@ function ld_command_db-backup_exec() {
     esac
 
     [ "$LD_VERBOSE" -ge "1" ] && echo -e "${Yellow}Using datestamp: $DATE${Color_Off}"
-    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}NEXT: docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c $COMMAND_SQL_DB_DUMPER${Color_Off}"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}NEXT: "$(compose_command) " -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c $COMMAND_SQL_DB_DUMPER${Color_Off}"
 
-    docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_DUMPER"
+    $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_DUMPER"
     cd $PROJECT_ROOT/${DATABASE_DUMP_STORAGE:-db_dumps}
     ln -sf ${FILENAME} db-backup--${DBNAME}--LATEST.sql.gz
 
     if [ -n "$STARTED" ]; then
        [ "$LD_VERBOSE" -ge "1" ] && echo -e "${Yellow}Stopping DB container.${Color_Off}"
-       COMM="docker-compose -f $DOCKER_COMPOSE_FILE stop $CONTAINER_DB"
+       COMM=$(compose_command) " -f $DOCKER_COMPOSE_FILE stop $CONTAINER_DB"
         [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
        $COMM
     fi

--- a/docker/scripts/ld.command.db-dump.sh
+++ b/docker/scripts/ld.command.db-dump.sh
@@ -19,7 +19,7 @@ function ld_command_db-dump_exec() {
           ;;
 
         2|"2")
-          COMM="docker-compose -f $DOCKER_COMPOSE_FILE  up -d $CONTAINER_DB"
+          COMM=$(compose_command) " -f $DOCKER_COMPOSE_FILE  up -d $CONTAINER_DB"
           [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Yellow}Starting DB container for backup purposes.${Color_Off}"
           $COMM
           STARTED=1
@@ -32,15 +32,15 @@ function ld_command_db-dump_exec() {
     esac
 
     [ "$LD_VERBOSE" -ge "1" ] && echo -e "${Yellow}Using datestamp: $DATE${Color_Off}"
-    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}NEXT: docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c $COMMAND_SQL_DB_DUMPER${Color_Off}"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}NEXT: "$(compose_command)" -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c $COMMAND_SQL_DB_DUMPER${Color_Off}"
 
-    docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_DUMPER"
+    $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_DUMPER"
     cd $PROJECT_ROOT/${DATABASE_DUMP_STORAGE:-db_dumps}
     ln -sf ${FILENAME} db-container--FULL--LATEST.sql.gz
 
     if [ -n "$STARTED" ]; then
        [ "$LD_VERBOSE" -ge "1" ] && echo -e "${Yellow}Stopping DB container.${Color_Off}"
-       COMM="docker-compose -f $DOCKER_COMPOSE_FILE stop $CONTAINER_DB"
+       COMM=$(compose_command) " -f $DOCKER_COMPOSE_FILE stop $CONTAINER_DB"
         [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
        $COMM
     fi

--- a/docker/scripts/ld.command.db-import.sh
+++ b/docker/scripts/ld.command.db-import.sh
@@ -62,17 +62,17 @@ function ld_command_db-import_exec() {
     echo
     if [ "$LD_VERBOSE" -ge "1" ]; then
         echo -e "${Yellow}Databases before the restore:${Color_Off}"
-        docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORE_INFO 2>/dev/null"
+        $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORE_INFO 2>/dev/null"
         echo
         echo "Verifying database backup file is found in the container, please wait..."
-        docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "[ -e "/var/${TARGET_FILE_NAME}" ] || echo 'File not found. Please place file inside db_dumps/ folder and provide full path (db_dumps/MY-FILE.tar.gz).'"
+        $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "[ -e "/var/${TARGET_FILE_NAME}" ] || echo 'File not found. Please place file inside db_dumps/ folder and provide full path (db_dumps/MY-FILE.tar.gz).'"
         echo "Please wait..."
-        docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORER 2>/dev/null"
+        $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORER 2>/dev/null"
         echo
         echo -e "${Yellow}Databases after the restore${Color_Off}"
-        docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORE_INFO 2>/dev/null"
+        $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORE_INFO 2>/dev/null"
         echo -e "${Yellow}Users after the restore${Color_Off}"
-        docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_USERS 2>/dev/null"
+        $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_USERS 2>/dev/null"
     fi
   }
 

--- a/docker/scripts/ld.command.db-restore.sh
+++ b/docker/scripts/ld.command.db-restore.sh
@@ -55,17 +55,17 @@ function ld_command_db-restore_exec() {
     echo
     if [ "$LD_VERBOSE" -ge "1" ]; then
         echo -e "${Yellow}Databases before the db-restore:${Color_Off}"
-        docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORE_INFO 2>/dev/null"
+        $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORE_INFO 2>/dev/null"
         echo
         echo "Verifying database backup file is found in the container, please wait..."
-        docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "[ -e "/var/${TARGET_FILE_NAME}" ] || echo 'File not found. Please place file inside db_dumps/ folder and provide full path (db_dumps/MY-FILE.tar.gz).'"
+        $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "[ -e "/var/${TARGET_FILE_NAME}" ] || echo 'File not found. Please place file inside db_dumps/ folder and provide full path (db_dumps/MY-FILE.tar.gz).'"
         echo "Please wait..."
-        docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORER 2>/dev/null"
+        $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORER 2>/dev/null"
         echo
         echo -e "${Yellow}Databases after the db-restore${Color_Off}"
-        docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORE_INFO 2>/dev/null"
+        $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORE_INFO 2>/dev/null"
         echo -e "${Yellow}Users after the db-restore${Color_Off}"
-        docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_USERS 2>/dev/null"
+        $(compose_command)-f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_USERS 2>/dev/null"
     fi
   }
 

--- a/docker/scripts/ld.command.down.sh
+++ b/docker/scripts/ld.command.down.sh
@@ -11,7 +11,7 @@ function ld_command_down_exec() {
         exit 1
     fi
 
-    COMM="docker-compose -f $DOCKER_COMPOSE_FILE down"
+    COMM=$(compose_command) " -f $DOCKER_COMPOSE_FILE down"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
     $COMM
 

--- a/docker/scripts/ld.command.drupal-files-folder-perms.sh
+++ b/docker/scripts/ld.command.drupal-files-folder-perms.sh
@@ -15,14 +15,14 @@ function ld_command_drupal-files-folder-perms_exec() {
     fi
 
     # Set folder perms, only, for speed.
-    COMM="docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'find /var/www/web/sites -type d -exec chown -R www-data {}'"
+    COMM=$(compose_command) " -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'find /var/www/web/sites -type d -exec chown -R www-data {}'"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
-    docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c "chown -R www-data:root /var/www/web/sites"
+    $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c "chown -R www-data:root /var/www/web/sites"
 
     # Set topmost file perms, only, for speed.
-    COMM="docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'find web/sites/ -maxdepth 2 -type f -exec chown -R www-data {}'"
+    COMM=$(compose_command)" -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'find web/sites/ -maxdepth 2 -type f -exec chown -R www-data {}'"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
-    docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c "chown -R www-data:root /var/www/web/sites"
+    $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c "chown -R www-data:root /var/www/web/sites"
 }
 
 function ld_command_drupal-files-folder-perms_help() {

--- a/docker/scripts/ld.command.drupal-structure-fix.sh
+++ b/docker/scripts/ld.command.drupal-structure-fix.sh
@@ -14,14 +14,14 @@ function ld_command_drupal-structure-fix_exec() {
       return 2
     fi
     [ "$LD_VERBOSE" -ge "1" ] && echo -e "${Yellow}Creating some folders and setting file perms to project below ${BYellow}${APP_ROOT}${Yellow}.${Color_Off}"
-    docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c '[[ ! -d "config/sync" ]] &&  mkdir -vp config/sync'
-    docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c '[[ ! -d "web/sites/default/files" ]] &&  mkdir -vp web/sites/default/files'
-    docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c '[[ ! -w "web/sites/default/files" ]] &&  chmod -r 0777 web/sites/default/files'
-    docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'if [ $(su -s /bin/sh www-data -c "test -w \"web/sites/default/files\"") ]; then echo "web/sites/default/files is writable - GREAT!"; else chmod -v a+wx web/sites/default/files; fi'
-    docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'if [ $(su -s /bin/sh www-data -c "test -w \"web/sites/default/settings.php\"") ]; then echo "web/sites/default/settings.php is writable - GREAT!"; else chmod -v a+w web/sites/default/settings.php; fi'
-    docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'mkdir -vp ./web/modules/custom && mkdir -vp ./web/themes/custom'
-    docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'echo > ./web/modules/custom/.gitkeep'
-    docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'echo > ./web/themes/custom/.gitkeep'
+    $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c '[[ ! -d "config/sync" ]] &&  mkdir -vp config/sync'
+    $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c '[[ ! -d "web/sites/default/files" ]] &&  mkdir -vp web/sites/default/files'
+    $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c '[[ ! -w "web/sites/default/files" ]] &&  chmod -r 0777 web/sites/default/files'
+    $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'if [ $(su -s /bin/sh www-data -c "test -w \"web/sites/default/files\"") ]; then echo "web/sites/default/files is writable - GREAT!"; else chmod -v a+wx web/sites/default/files; fi'
+    $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'if [ $(su -s /bin/sh www-data -c "test -w \"web/sites/default/settings.php\"") ]; then echo "web/sites/default/settings.php is writable - GREAT!"; else chmod -v a+w web/sites/default/settings.php; fi'
+    $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'mkdir -vp ./web/modules/custom && mkdir -vp ./web/themes/custom'
+    $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'echo > ./web/modules/custom/.gitkeep'
+    $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_PHP:-php} bash -c 'echo > ./web/themes/custom/.gitkeep'
 }
 
 function ld_command_drupal-structure-fix_help() {

--- a/docker/scripts/ld.command.drush.sh
+++ b/docker/scripts/ld.command.drush.sh
@@ -13,7 +13,7 @@ function ld_command_drush_exec() {
       echo -e "${Red}ERROR: PHP container ('${CONTAINER_PHP:-php}')is not up.${Color_Off}"
       return 2
     fi
-    COMM="docker-compose exec -T ${CONTAINER_PHP:-php} /var/www/vendor/drush/drush/drush $@"
+    COMM=$(compose_command) " exec -T ${CONTAINER_PHP:-php} /var/www/vendor/drush/drush/drush $@"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
     $COMM
 }

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -181,9 +181,9 @@ function ld_command_init_exec() {
     ensure_folders_present $DATABASE_DUMP_STORAGE
     echo -e "${BYellow}INFO: ${Yellow}Database dumps will be placed in ${BYellow}$DATABASE_DUMP_STORAGE${Yellow}.${Color_Off}"
 
-    if [[ "$(docker-compose -f $DOCKER_COMPOSE_FILE ps -q)" ]]; then
+    if [[ "$($(compose_command) -f $DOCKER_COMPOSE_FILE ps -q)" ]]; then
         echo -n "Turning off current container stack, please wait..."
-        docker-compose -f $DOCKER_COMPOSE_FILE down 2> /dev/null
+        $(compose_command) -f $DOCKER_COMPOSE_FILE down 2> /dev/null
         echo  -e "${Green}DONE${Color_Off}"
     fi
 
@@ -203,16 +203,16 @@ function ld_command_init_exec() {
 
     echo
     echo -e "${Yellow}Starting a temporary ${BYellow}Composer${Yellow} container only for the codebase building, please wait...${Color_Off}"
-    docker-compose -f $DOCKER_COMPOSER_ONLY_FILE up -d
+    $(compose_command) -f $DOCKER_COMPOSER_ONLY_FILE up -d
     echo -e "${BGreen}Composer${Green} container started.${Color_Off}"
 
     echo
     echo "Verify application root can be used to install codebase (must be empty)..."
 
     FILE_COUNTER='find /var/www -maxdepth 1 | egrep -v "^\/var\/www$" | wc -l'
-    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: docker-compose -f $DOCKER_COMPOSER_ONLY_FILE exec -T composer bash -c \"$FILE_COUNTER\"${Color_Off}"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: "$(compose_command)" -f $DOCKER_COMPOSER_ONLY_FILE exec -T composer bash -c \"$FILE_COUNTER\"${Color_Off}"
     [ "$LD_VERBOSE" -ge "2" ] && echo -n "Files (count) in ./${APP_ROOT}: "
-    APP_FILES_COUNT=$(docker-compose -f $DOCKER_COMPOSER_ONLY_FILE exec -T composer bash -c "$FILE_COUNTER")
+    APP_FILES_COUNT=$($(compose_command)  -f $DOCKER_COMPOSER_ONLY_FILE exec -T composer bash -c "$FILE_COUNTER")
     # Clean up response from newlines and stuff to make it integer~ish.
     APP_FILES_COUNT=$(echo $APP_FILES_COUNT |tr -d '\r' |tr -d '\n' |tr -d ' ')
 
@@ -226,7 +226,7 @@ function ld_command_init_exec() {
 
     if [ -z "$APP_FILES_COUNT" ]; then
         echo -e "${Red}ERROR: Could not check files count in application root ./${APP_ROOT}.${Color_Off}"
-        docker-compose -f $DOCKER_COMPOSER_ONLY_FILE down
+        $(compose_command) -f $DOCKER_COMPOSER_ONLY_FILE down
         return 1
     elif [ "$APP_FILES_COUNT" -ne "0" ]; then
         echo "Application root folder ./$APP_ROOT is not empty. Installation requires an empty folder."
@@ -240,12 +240,12 @@ function ld_command_init_exec() {
             'PLEASE-DELETE' )
                 echo "Clearing old things from the app root."
                 CLEAN_ROOT="rm -rf /var/www/{,.[!.],..?}*"
-                [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: docker-compose -f $DOCKER_COMPOSER_ONLY_FILE exec -T composer bash -c \"$CLEAN_ROOT\"${Color_Off}"
-                docker-compose -f $DOCKER_COMPOSER_ONLY_FILE exec -T composer bash -c "$CLEAN_ROOT"
+                [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: "$(compose_command) " -f $DOCKER_COMPOSER_ONLY_FILE exec -T composer bash -c \"$CLEAN_ROOT\"${Color_Off}"
+                $(compose_command) -f $DOCKER_COMPOSER_ONLY_FILE exec -T composer bash -c "$CLEAN_ROOT"
                 ;;
             *)
                 echo -e "${Red}ERROR: Application can't be installed to a non-empty folder ./${APP_ROOT}.${Color_Off}"
-                docker-compose -f $DOCKER_COMPOSER_ONLY_FILE down
+                $(compose_command) -f $DOCKER_COMPOSER_ONLY_FILE down
                 return 1
                 ;;
         esac
@@ -315,22 +315,22 @@ function ld_command_init_exec() {
 
     if [ -n "$COMPOSER_INIT" ]; then
       # Use verbose output on this composer command.
-      [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: docker-compose -f $DOCKER_COMPOSER_ONLY_FILE exec -T php bash -c \"COMPOSER_MEMORY_LIMIT=-1 $COMPOSER_INIT\"${Color_Off}"
+      [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: "$(compose_command)" -f $DOCKER_COMPOSER_ONLY_FILE exec -T php bash -c \"COMPOSER_MEMORY_LIMIT=-1 $COMPOSER_INIT\"${Color_Off}"
       # Turn off PHP memory limit for the create project -phase (only).
-      docker-compose -f $DOCKER_COMPOSER_ONLY_FILE exec -T composer bash -c "COMPOSER_MEMORY_LIMIT=-1  $COMPOSER_INIT"
+      $(compose_command) -f $DOCKER_COMPOSER_ONLY_FILE exec -T composer bash -c "COMPOSER_MEMORY_LIMIT=-1  $COMPOSER_INIT"
       OK=$?
       if [ "$OK" -ne "0" ]; then
           echo -e "${BRed}ERROR${Red}: Something went wrong when initializing the codebase.${Color_Off}"
           echo -e "${Red}Check that required ports are not allocated (by other containers or programs) and re-configure them if needed.${Color_Off}"
-          docker-compose -f $DOCKER_COMPOSER_ONLY_FILE down
+          $(compose_command) -f $DOCKER_COMPOSER_ONLY_FILE down
           cd $CWD
           return 1
       fi
       if [ -n "$POST_COMPOSER_INIT" ]; then
           # Use verbose output on this composer command.
-          [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: docker-compose -f $DOCKER_COMPOSER_ONLY_FILE exec -T php bash -c \"COMPOSER_MEMORY_LIMIT=-1 $POST_COMPOSER_INIT\"${Color_Off}"
+          [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: "$(compose_command)" -f $DOCKER_COMPOSER_ONLY_FILE exec -T php bash -c \"COMPOSER_MEMORY_LIMIT=-1 $POST_COMPOSER_INIT\"${Color_Off}"
           # Turn off PHP memory limit for these commands.
-          docker-compose -f $DOCKER_COMPOSER_ONLY_FILE exec -T composer bash -c "COMPOSER_MEMORY_LIMIT=-1 $POST_COMPOSER_INIT"
+          $(compose_command) -f $DOCKER_COMPOSER_ONLY_FILE exec -T composer bash -c "COMPOSER_MEMORY_LIMIT=-1 $POST_COMPOSER_INIT"
       fi
 
       echo
@@ -339,7 +339,7 @@ function ld_command_init_exec() {
       echo -e "${Green}Project root is set to ./$APP_ROOT folder (/var/www in containers).${Color_Off}"
     fi
 
-    docker-compose -f $DOCKER_COMPOSER_ONLY_FILE down
+    $(compose_command) -f $DOCKER_COMPOSER_ONLY_FILE down
 
     if [ "$LD_VERBOSE" -ge "1" ] ; then
         echo
@@ -351,8 +351,8 @@ function ld_command_init_exec() {
     if [ -z "$COMPOSER_INIT" ]; then
         echo
         echo -e "${Yellow}NOTE: Once Drupal is installed, you should remove write perms in sites/default -folder:${Color_Off}"
-        echo "docker-compose -f $DOCKER_COMPOSE_FILE exec -T php bash -c 'chmod -v 0755 web/sites/default'"
-        echo "docker-compose -f $DOCKER_COMPOSE_FILE exec -T php bash -c 'chmod -v 0644 web/sites/default/settings.php'"
+        echo $(compose_command) " -f $DOCKER_COMPOSE_FILE exec -T php bash -c 'chmod -v 0755 web/sites/default'"
+        echo $(compose_command) " -f $DOCKER_COMPOSE_FILE exec -T php bash -c 'chmod -v 0644 web/sites/default/settings.php'"
         echo "With these changes you can edit settings.php from host, but keep Drupal happy and allow it to write these files."
     fi
 

--- a/docker/scripts/ld.command.nuke-volumes.sh
+++ b/docker/scripts/ld.command.nuke-volumes.sh
@@ -18,7 +18,7 @@ function ld_command_nuke-volumes_exec() {
         sleep 1
     done
     echo
-    docker-compose -f $DOCKER_COMPOSE_FILE down
+    $(compose_command) -f $DOCKER_COMPOSE_FILE down
     if is_dockersync; then
         [ "$LD_VERBOSE" -ge "1" ] && echo 'Turning off docker-sync (clean), please wait...'
         docker-sync clean

--- a/docker/scripts/ld.command.phpcbf.sh
+++ b/docker/scripts/ld.command.phpcbf.sh
@@ -13,7 +13,7 @@ function ld_command_phpcbf_exec() {
       echo -e "${Red}ERROR: PHP container ('${CONTAINER_PHP:-php}')is not up.${Color_Off}"
       return 2
     fi
-    COMM="docker-compose exec -T ${CONTAINER_PHP:-php} /var/www/vendor/bin/phpcbf $@"
+    COMM=$(compose_command) " exec -T ${CONTAINER_PHP:-php} /var/www/vendor/bin/phpcbf $@"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
     $COMM
 }

--- a/docker/scripts/ld.command.phpcs.sh
+++ b/docker/scripts/ld.command.phpcs.sh
@@ -13,7 +13,7 @@ function ld_command_phpcs_exec() {
       echo -e "${Red}ERROR: PHP container ('${CONTAINER_PHP:-php}')is not up.${Color_Off}"
       return 2
     fi
-    COMM="docker-compose exec -T ${CONTAINER_PHP:-php} /var/www/vendor/bin/phpcs $@"
+    COMM=$(compose_command) " exec -T ${CONTAINER_PHP:-php} /var/www/vendor/bin/phpcs $@"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
     $COMM
 }

--- a/docker/scripts/ld.command.rebuild.sh
+++ b/docker/scripts/ld.command.rebuild.sh
@@ -8,7 +8,7 @@ function ld_command_rebuild_exec() {
     [ "$LD_VERBOSE" -lt "1" ] $SCRIPT_NAME down 2&>/dev/null
     # Return value is not important here.
     [ "$LD_VERBOSE" -ge "1" ] && echo "(re)Building containers, please wait..."
-    docker-compose -f $DOCKER_COMPOSE_FILE build
+    $(compose_command) -f $DOCKER_COMPOSE_FILE build
     $SCRIPT_NAME up
     $SCRIPT_NAME db-restore
 }

--- a/docker/scripts/ld.command.run-tests.sh
+++ b/docker/scripts/ld.command.run-tests.sh
@@ -15,8 +15,8 @@ function ld_command_run-tests_exec() {
     fi
     TESTS=${@}
     SUB_COMM="/bin/su -s /bin/bash www-data -c 'test -f  web/core/scripts/run-tests.sh && php web/core/scripts/run-tests.sh --verbose --non-html --url http://${CONTAINER_NGINX:-nginx} --color ${TESTS} '"
-    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: docker-compose exec -T ${CONTAINER_PHP:-php} bash -c \"${SUB_COMM}\"${Color_Off}"
-    docker-compose exec -T ${CONTAINER_PHP:-php} bash -c "${SUB_COMM}"
+    [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: "$(compose_command)" exec -T ${CONTAINER_PHP:-php} bash -c \"${SUB_COMM}\"${Color_Off}"
+    $(compose_command) exec -T ${CONTAINER_PHP:-php} bash -c "${SUB_COMM}"
 }
 
 function ld_command_run-tests_help() {

--- a/docker/scripts/ld.command.stop.sh
+++ b/docker/scripts/ld.command.stop.sh
@@ -8,7 +8,7 @@ function ld_command_stop_exec() {
     echo -e "${Yellow}No backup of database content created.${Color_Off}"
     echo -e "${Yellow}You may create one using command './ld db-dump' or './ld db-backup [db-name]'.${Color_Off}"
 
-    COMM="docker-compose -f $DOCKER_COMPOSE_FILE stop"
+    COMM=$(compose_command)" -f $DOCKER_COMPOSE_FILE stop"
     [ "$LD_VERBOSE" -ge "2" ] && echo -e "${Cyan}Next: $COMM${Color_Off}"
     $COMM
 

--- a/docker/scripts/ld.command.up.sh
+++ b/docker/scripts/ld.command.up.sh
@@ -15,7 +15,7 @@ function ld_command_up_exec() {
         docker-sync start
     fi
     ensure_folders_present ${DATABASE_DUMP_STORAGE:-db_dumps}
-    docker-compose -f $DOCKER_COMPOSE_FILE up -d
+    $(compose_command) -f $DOCKER_COMPOSE_FILE up -d
     $SCRIPT_NAME drupal-files-folder-perms
     OK=$?
     if [ "$OK" -ne "0" ]; then
@@ -48,9 +48,9 @@ function ld_command_up_exec() {
     echo
     if [ "$LD_VERBOSE" -ge "1" ]; then
         echo -e "${Yellow}Current databases:${Color_Off}"
-        docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORE_INFO 2>/dev/null"
+        $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_RESTORE_INFO 2>/dev/null"
         echo -e "${Yellow}Current database users:${Color_Off}"
-        docker-compose -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_USERS 2>/dev/null"
+        $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T ${CONTAINER_DB:-db} sh -c "$COMMAND_SQL_DB_USERS 2>/dev/null"
         echo -e "${Yellow}NOTE: No database dump restored.${Color_Off}"
         echo 'In case you need to do that (Drupal DB is gone?), run command'
         echo '$ '$SCRIPT_NAME_SHORT db-import [drupal]

--- a/docker/scripts/ld.command.xdebug.sh
+++ b/docker/scripts/ld.command.xdebug.sh
@@ -7,9 +7,9 @@ function ld_command_xdebug_exec() {
     # NOTE we push these values to developer's local ENV file .env.local to
     # avoid repeated changes known by Git in the project level file.
     case "$1" in
-        '1'|'on') define_configuration_value PHP_XDEBUG_REMOTE_ENABLE 1 .env.local; sleep 1; docker-compose -f $DOCKER_COMPOSE_FILE up -d php && $SCRIPT_NAME xdebug;;
-        '0'|'off') define_configuration_value PHP_XDEBUG_REMOTE_ENABLE 0 .env.local; docker-compose -f $DOCKER_COMPOSE_FILE up -d php && $SCRIPT_NAME xdebug;;
-        *) docker-compose -f $DOCKER_COMPOSE_FILE exec -T php bash -c 'echo -n "Xdebug is: "; php -i | grep xdebug.remote_enable |tr -s " => " "|" | cut -d "|" -f2';;
+        '1'|'on') define_configuration_value PHP_XDEBUG_REMOTE_ENABLE 1 .env.local; sleep 1; $(compose_command) -f $DOCKER_COMPOSE_FILE up -d php && $SCRIPT_NAME xdebug;;
+        '0'|'off') define_configuration_value PHP_XDEBUG_REMOTE_ENABLE 0 .env.local; $(compose_command) -f $DOCKER_COMPOSE_FILE up -d php && $SCRIPT_NAME xdebug;;
+        *) $(compose_command) -f $DOCKER_COMPOSE_FILE exec -T php bash -c 'echo -n "Xdebug is: "; php -i | grep xdebug.remote_enable |tr -s " => " "|" | cut -d "|" -f2';;
     esac
 
 }

--- a/docker/scripts/ld.functions.sh
+++ b/docker/scripts/ld.functions.sh
@@ -3,6 +3,20 @@
 #
 # This file contains functions for local-docker script ld.sh.
 
+# Command to return the executable.
+# Some future day this will return path to
+# - /path/to/docker-compose OR
+# - /path/to/mutagen compose (Mutagen.io wrapper to docker-compose)
+function compose_command() {
+    COMMAND=$(which docker-compose)
+    if [ "$?" -ne "0" ]; then
+        exit 1
+    fi
+    # NOTE .env / .env.local files have not yet been sourced, so the custom
+    # variables are not yet present.
+    echo $COMMAND
+}
+
 function find_container() {
     if [ -z "$1" ]; then
         return 1


### PR DESCRIPTION
In preparation to enable use of Mutagen.io in local-docker replace 
all direct calls to docker-compose with a wrapper function. This 
wrapper can be used to determine if user has cabability to use
Mutagen.io's Compose command, and return correct callback. 

Command `mutagen compose` is merely a wrapper around docker-compose but 
starts up some caching containers first. 

﻿- Add wrapper to get docker-compose command
- Convert direct calls to docker-compose with wrapper callback

Before submitting your PR, please review the following checklist:

- [ ] Keep pull request small so it can be easily reviewed.
- [ ] Refer to the related issue (`#123`) in PR description.
- [ ] Describe the proposed changes.

