### PR TITLE
Use latest 7.3-1.2 tag from php-drupal image

### DIFF
--- a/docker/build/php/7.3/Dockerfile
+++ b/docker/build/php/7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM xoxoxo/php-drupal:7.3-1.1
+FROM xoxoxo/php-drupal:7.3-1.2
 
 # Configure PHP for local development.
 COPY ./conf.d/90-mailhog.ini /usr/local/etc/php/conf.d/90-mailhog.ini


### PR DESCRIPTION
Base image for PHP 7.3 has a new version, php-drupal:7.3-1.2.

The image cotains newer PHP 7.3, Xdebug 2.9 and Composer 2(!).

- [x] Keep pull request small so it can be easily reviewed.
- [ ] Refer to the related issue (`#123`) in PR description.
- [x] Describe the proposed changes.

