### PR TITLE
Custom mysql configs / Changing database collation to utf8mb4_swedish…

### DIFF
--- a/docker/configs/mysql/development.cnf
+++ b/docker/configs/mysql/development.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+# Set max_allowed_packet to 256M (or any other value)
+max_allowed_packet=256M

--- a/docker/configs/mysql/force-utf8mb4.cnf
+++ b/docker/configs/mysql/force-utf8mb4.cnf
@@ -1,0 +1,10 @@
+[mysql]
+default-character-set=utf8mb4
+
+[mysqld]
+character-set-server=utf8mb4 
+collation-server = utf8mb4_swedish_ci
+init-connect='SET NAMES utf8mb4'
+init_connect='SET collation_connection = utf8mb4_swedish_ci'
+init_connect='SET collation_database = utf8mb4_swedish_ci' 
+skip-character-set-client-handshake

--- a/docker/docker-compose.cached.yml
+++ b/docker/docker-compose.cached.yml
@@ -138,6 +138,9 @@ services:
       # unless stack is down'ed with "--volumes":
       # $ docker-compose down --volumes
       - db_data:/var/lib/mysql
+      # Custom MySQL configs.
+      - ./docker/configs/mysql/development.cnf:/etc/mysql/conf.d/development.cnf
+      - ./docker/configs/mysql/force-utf8mb4.cnf:/etc/mysql/conf.d/force-utf8mb4.cnf
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -145,8 +148,6 @@ services:
       - .env.local
     restart: on-failure
     working_dir: /var
-    # Set max_allowed_packet to 256M (or any other value)
-    command: --max_allowed_packet=268435456
 
   # Maybe use this instead of the one set blow here: https://hub.docker.com/r/eeacms/varnish/
   # varnish:

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -138,6 +138,9 @@ services:
       # unless stack is down'ed with "--volumes":
       # $ docker-compose down --volumes
       - db_data:/var/lib/mysql
+      # Custom MySQL configs.
+      - ./docker/configs/mysql/development.cnf:/etc/mysql/conf.d/development.cnf
+      - ./docker/configs/mysql/force-utf8mb4.cnf:/etc/mysql/conf.d/force-utf8mb4.cnf
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -145,8 +148,6 @@ services:
       - .env.local
     restart: on-failure
     working_dir: /var
-    # Set max_allowed_packet to 256M (or any other value)
-    command: --max_allowed_packet=268435456
 
   # Maybe use this instead of the one set blow here: https://hub.docker.com/r/eeacms/varnish/
   # varnish:

--- a/docker/docker-compose.ddev.yml
+++ b/docker/docker-compose.ddev.yml
@@ -139,6 +139,9 @@ services:
       # unless stack is down'ed with "--volumes":
       # $ docker-compose down --volumes
       - db_data:/var/lib/mysql
+      # Custom MySQL configs.
+      - ./docker/configs/mysql/development.cnf:/etc/mysql/conf.d/development.cnf
+      - ./docker/configs/mysql/force-utf8mb4.cnf:/etc/mysql/conf.d/force-utf8mb4.cnf
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -146,8 +149,6 @@ services:
       - .env.local
     restart: on-failure
     working_dir: /var
-    # Set max_allowed_packet to 256M (or any other value)
-    command: --max_allowed_packet=268435456
 
   # Maybe use this instead of the one set blow here: https://hub.docker.com/r/eeacms/varnish/
   # varnish:

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -139,6 +139,9 @@ services:
       # unless stack is down'ed with "--volumes":
       # $ docker-compose down --volumes
       - db_data:/var/lib/mysql
+      # Custom MySQL configs.
+      - ./docker/configs/mysql/development.cnf:/etc/mysql/conf.d/development.cnf
+      - ./docker/configs/mysql/force-utf8mb4.cnf:/etc/mysql/conf.d/force-utf8mb4.cnf
     # In case of several env files later declared variable
     # values override earlier ones
     # In case of several env files later declared variable
@@ -148,8 +151,6 @@ services:
       - .env.local
     restart: on-failure
     working_dir: /var
-    # Set max_allowed_packet to 256M (or any other value)
-    command: --max_allowed_packet=268435456
 
   # Maybe use this instead of the one set blow here: https://hub.docker.com/r/eeacms/varnish/
   # varnish:

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -143,6 +143,9 @@ services:
       # unless stack is down'ed with "--volumes":
       # $ docker-compose down --volumes
       - db_data:/var/lib/mysql
+      # Custom MySQL configs.
+      - ./docker/configs/mysql/development.cnf:/etc/mysql/conf.d/development.cnf
+      - ./docker/configs/mysql/force-utf8mb4.cnf:/etc/mysql/conf.d/force-utf8mb4.cnf
     # In case of several env files later declared variable
     # values override earlier ones
     env_file:
@@ -150,8 +153,6 @@ services:
       - .env.local
     restart: on-failure
     working_dir: /var
-    # Set max_allowed_packet to 256M (or any other value)
-    command: --max_allowed_packet=268435456
 
   # Maybe use this instead of the one set blow here: https://hub.docker.com/r/eeacms/varnish/
   # varnish:


### PR DESCRIPTION
- Create a development mysql config
- Set default DB collation to utf8mb4_swedish_ci
- Set default character set to utf8mb4

Changes to Drupal settings.php still should be done manually