### PR TITLE
Add PHP 7.4, update PHP 7.3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,7 @@ MYSQL_PASSWORD=drupal
 # Valid options are 7.1, 7.2 (see build file paths in docker/build/php).
 # Changes to this value will take effect only after buiding PHP container:
 # $ docker-compose up -d --build php
-# Valid values: 7.1, 7.2, 7.3
+# Valid values: 7.1, 7.2, 7.3, 7.4
 PROJECT_PHP_VERSION=
 
 # Let the composer run as root without constant complaining.

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ commands `php` container tries to connect to your IDE:
 This Xdebug configuration is initially set in the base image this
 project is using (`xoxoxo/php-container`). However, this can be
 overridden for example in
-[95-drupal-development.ini file (PHP 7.4](./docker/build/php7.4/conf.d/95-drupal-development.ini)
+[95-drupal-development.ini file [PHP 7.4](./docker/build/php7.4/conf.d/95-drupal-development.ini)
 , and Xdebug's full config can be checked either from Drupal
 (`admin/reports/status/php`) or with command
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ commands `php` container tries to connect to your IDE:
 This Xdebug configuration is initially set in the base image this
 project is using (`xoxoxo/php-container`). However, this can be
 overridden for example in
-[95-drupal-development.ini file [PHP 7.4](./docker/build/php7.4/conf.d/95-drupal-development.ini)
+[95-drupal-development.ini file (PHP 7.4)](./docker/build/php7.4/conf.d/95-drupal-development.ini)
 , and Xdebug's full config can be checked either from Drupal
 (`admin/reports/status/php`) or with command
 

--- a/README.md
+++ b/README.md
@@ -417,9 +417,9 @@ commands `php` container tries to connect to your IDE:
     xdebug.remote_host = host.docker.internal
 
 This Xdebug configuration is initially set in the base image this
-project is using (`xoxoxo/php-container`). However this can be
+project is using (`xoxoxo/php-container`). However, this can be
 overridden for example in
-[95-drupal-development.ini file (PHP 7.3)](./docker/build/php7.3/conf.d/95-drupal-development.ini)
+[95-drupal-development.ini file (PHP 7.4](./docker/build/php7.4/conf.d/95-drupal-development.ini)
 , and Xdebug's full config can be checked either from Drupal
 (`admin/reports/status/php`) or with command
 

--- a/docker/build/php/7.3/Dockerfile
+++ b/docker/build/php/7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM xoxoxo/php-drupal:7.3-1.1
+FROM xoxoxo/php-drupal:7.3-1.3
 
 # Configure PHP for local development.
 COPY ./conf.d/90-mailhog.ini /usr/local/etc/php/conf.d/90-mailhog.ini

--- a/docker/build/php/7.3/bash/bashrc
+++ b/docker/build/php/7.3/bash/bashrc
@@ -2,7 +2,6 @@ PS1="\w # "
 alias ls='ls -F'
 alias ll='ls -lha'
 alias drupal=/var/www/vendor/drupal/console/bin/drupal
-alias drush=/var/www/vendor/drush/drush/drush
 
 echo
 echo "Welcome to PHP container!!"
@@ -11,11 +10,10 @@ echo "PHP version is $(php --version |grep 'built')"
 echo
 echo "Time in this container is $(date +%Y-%m-%d\ %H\:\%M\:%S\ %z\ \(%Z\))."
 echo
-echo "Drush and Drupal console are aliased, so you can "
-echo "use them from wherever you like:"
-echo -n "\$ drush => ${BASH_ALIASES[drush]}"
-test -e ${BASH_ALIASES[drush]} && echo || echo " (target not yet created)"
+echo "Drupal console is aliased, so you can "
+echo "use it from wherever you like:"
 echo -n "\$ drupal => ${BASH_ALIASES[drupal]}"
 test -e ${BASH_ALIASES[drupal]} && echo || echo " (target not yet created)"
-echo
+echo "Drush is called via Drush Launcher and it should find the correct site in a breeze."
+echo ""
 echo "Happy coding!"

--- a/docker/build/php/7.4/Dockerfile
+++ b/docker/build/php/7.4/Dockerfile
@@ -1,0 +1,10 @@
+FROM xoxoxo/php-drupal:7.4-1.0
+
+# Configure PHP for local development.
+COPY ./conf.d/90-mailhog.ini /usr/local/etc/php/conf.d/90-mailhog.ini
+
+# Configure PHP to send all mail to Mailhog.
+COPY ./conf.d/95-drupal-development.ini /usr/local/etc/php/conf.d/95-drupal-development.ini
+
+# Add some aliases to Bash
+COPY ./bash/bashrc /root/.bashrc

--- a/docker/build/php/7.4/bash/bashrc
+++ b/docker/build/php/7.4/bash/bashrc
@@ -1,0 +1,19 @@
+PS1="\w # "
+alias ls='ls -F'
+alias ll='ls -lha'
+alias drupal=/var/www/vendor/drupal/console/bin/drupal
+
+echo
+echo "Welcome to PHP container!!"
+echo
+echo "PHP version is $(php --version |grep 'built')"
+echo
+echo "Time in this container is $(date +%Y-%m-%d\ %H\:\%M\:%S\ %z\ \(%Z\))."
+echo
+echo "Drupal console is aliased, so you can "
+echo "use it from wherever you like:"
+echo -n "\$ drupal => ${BASH_ALIASES[drupal]}"
+test -e ${BASH_ALIASES[drupal]} && echo || echo " (target not yet created)"
+echo "Drush is called via Drush Launcher and it should find the correct site in a breeze."
+echo ""
+echo "Happy coding!"

--- a/docker/build/php/7.4/conf.d/90-mailhog.ini
+++ b/docker/build/php/7.4/conf.d/90-mailhog.ini
@@ -1,0 +1,1 @@
+sendmail_path = /usr/sbin/sendmail -S mailhog:1025

--- a/docker/build/php/7.4/conf.d/95-drupal-development.ini
+++ b/docker/build/php/7.4/conf.d/95-drupal-development.ini
@@ -1,0 +1,24 @@
+; Base config is already in, but here are some overrides.
+; Any changes here will be applied only after rebuilding `php` container.
+; In local-docker some values are set via environment variables.
+
+allow_url_fopen = 1
+display_errors = 1
+memory_limit = ${PHP_MEMORY_LIMIT}
+file_uploads = 1
+post_max_size = 500M
+upload_max_filesize = 500M
+max_execution_time = 600
+max_children = 8
+error_reporting = E_ALL
+
+opcache.validate_timestamps=1
+
+; ============
+; XDEBUG conf
+; ============
+;
+xdebug.remote_enable = ${PHP_XDEBUG_REMOTE_ENABLE}
+xdebug.remote_host=  ${PHP_XDEBUG_REMOTE_HOST}
+xdebug.remote_port = ${PHP_XDEBUG_REMOTE_PORT}
+xdebug.remote_log = ${PHP_XDEBUG_REMOTE_LOG}

--- a/docker/docker--composer-only.yml
+++ b/docker/docker--composer-only.yml
@@ -8,7 +8,7 @@ version: '3.3'
 services:
   composer:
     # Runs `composer install` during startup.
-    build: ../docker/build/php/${PROJECT_PHP_VERSION:-7.3}
+    build: ../docker/build/php/${PROJECT_PHP_VERSION:-7.4}
     container_name: "${PROJECT_NAME}_composer"
     volumes:
       # Declaring only one volume with on volumes within allows building

--- a/docker/docker-compose.cached.yml
+++ b/docker/docker-compose.cached.yml
@@ -108,7 +108,7 @@ services:
     # Available builds: https://hub.docker.com/r/xoxoxo/php-container/tags
     # Custom build contains sendmail_path -fix for Mailhog and OPTION to add
     # overrides (per project) to other PHP config.
-    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
+    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.4}
     container_name: "${PROJECT_NAME}_php"
     volumes:
       # :cached must be used with docker-sync

--- a/docker/docker-compose.common.yml
+++ b/docker/docker-compose.common.yml
@@ -108,7 +108,7 @@ services:
     # Available builds: https://hub.docker.com/r/xoxoxo/php-container/tags
     # Custom build contains sendmail_path -fix for Mailhog and OPTION to add
     # overrides (per project) to other PHP config.
-    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
+    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.4}
     container_name: "${PROJECT_NAME}_php"
     volumes:
       # :nocopy must be used with docker-sync

--- a/docker/docker-compose.ddev.yml
+++ b/docker/docker-compose.ddev.yml
@@ -109,7 +109,7 @@ services:
     # Available builds: https://hub.docker.com/r/xoxoxo/php-container/tags
     # Custom build contains sendmail_path -fix for Mailhog and OPTION to add
     # overrides (per project) to other PHP config.
-    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
+    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.4}
     container_name: "${PROJECT_NAME}_php"
     volumes:
       # :nocopy must be used with docker-sync

--- a/docker/docker-compose.nfs.yml
+++ b/docker/docker-compose.nfs.yml
@@ -115,7 +115,7 @@ services:
     # Available builds: https://hub.docker.com/r/xoxoxo/php-container/tags
     # Custom build contains sendmail_path -fix for Mailhog and OPTION to add
     # overrides (per project) to other PHP config.
-    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
+    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.4}
     container_name: "${PROJECT_NAME}_php"
     volumes:
       - webroot-nfs-app:/var/www

--- a/docker/docker-compose.skeleton.yml
+++ b/docker/docker-compose.skeleton.yml
@@ -109,7 +109,7 @@ services:
     # Available builds: https://hub.docker.com/r/xoxoxo/php-container/tags
     # Custom build contains sendmail_path -fix for Mailhog and OPTION to add
     # overrides (per project) to other PHP config.
-    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.3}
+    build: ./docker/build/php/${PROJECT_PHP_VERSION:-7.4}
     container_name: "${PROJECT_NAME}_php"
     volumes:
       # :nocopy must be used with docker-sync

--- a/docker/scripts/ld.command.init.sh
+++ b/docker/scripts/ld.command.init.sh
@@ -143,12 +143,14 @@ function ld_command_init_exec() {
     while [ -z "$PROJECT_PHP_VERSION" ]; do
         echo "What is the PHP version to use?"
         echo "Options:"
-        echo " [1] - PHP 7.1"
+        echo " [4] - PHP 7.4 (default)"
+        echo " [3] - PHP 7.3"
         echo " [2] - PHP 7.2"
-        echo " [3] - PHP 7.3 (default)"
+        echo " [1] - PHP 7.1"
         read -p "Select version: " VERSION
         case "$VERSION" in
-            ''|'3'|3) PROJECT_PHP_VERSION='7.3';;
+            ''|'4'|4) PROJECT_PHP_VERSION='7.4';;
+            '3'|3) PROJECT_PHP_VERSION='7.3';;
             '2'|2) PROJECT_PHP_VERSION='7.2';;
             '1'|1) PROJECT_PHP_VERSION='7.1';;
             *) echo -e "${Red}ERROR: PHP version selection failed. Please use the available options.${Color_Off}"


### PR DESCRIPTION
Add PHP 7.4 via new base image for `php` container.

Update PHP 7.3 base image. 

This updates (via base image) Xdebug to 3.x, too.

Both updates bring also Drush launcher into the `php` container.

- Update PHP 7.3 base to newer image
- Add PHP 7.4 image
- Minor text fixes
- Make PHP 7.4 the default version

Before submitting your PR, please review the following checklist:

- [ ] Keep pull request small so it can be easily reviewed.
- [ ] Refer to the related issue (`#123`) in PR description.
- [ ] Describe the proposed changes.

